### PR TITLE
Added MapMerge

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/monoid/builtin/MergeMaps.java
+++ b/src/main/java/com/jnape/palatable/lambda/monoid/builtin/MergeMaps.java
@@ -1,0 +1,55 @@
+package com.jnape.palatable.lambda.monoid.builtin;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.specialized.BiMonoidFactory;
+import com.jnape.palatable.lambda.functions.specialized.MonoidFactory;
+import com.jnape.palatable.lambda.monoid.Monoid;
+import com.jnape.palatable.lambda.semigroup.Semigroup;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+/**
+ * A {@link Monoid} instance formed by {@link Map#merge(K, V, BiFunction)} and a semigroup over <code>V</code>.
+ * Combines together multiple maps using the provided semigroup for key collisions.
+ *
+ * @param <K> The key parameter type of the Map
+ * @param <V> The value parameter type of the Map
+ * @see Monoid
+ * @see java.util.Map
+ */
+public class MergeMaps<K, V> implements BiMonoidFactory<Supplier<Map<K, V>>, Semigroup<V>, Map<K, V>> {
+    private MergeMaps() {
+    }
+
+    @Override
+    public Monoid<Map<K, V>> apply(Supplier<Map<K, V>> mSupplier, Semigroup<V> semigroup) {
+        return Monoid.<Map<K, V>>monoid((x, y) -> {
+            Map<K, V> copy = mSupplier.get();
+            copy.putAll(x);
+            y.forEach((k, v) -> copy.merge(k, v, semigroup.toBiFunction()));
+            return copy;
+        }, mSupplier);
+    }
+
+    public static <A, B> MergeMaps<A, B> mergeMaps() {
+        return new MergeMaps<>();
+    }
+
+    public static <A, B> MonoidFactory<Semigroup<B>, Map<A, B>> mergeMaps(Supplier<Map<A, B>> mSupplier) {
+        return MergeMaps.<A, B>mergeMaps().apply(mSupplier);
+    }
+
+    public static <A, B> Monoid<Map<A, B>> mergeMaps(Supplier<Map<A, B>> mSupplier, Semigroup<B> semigroup) {
+        return mergeMaps(mSupplier).apply(semigroup);
+    }
+
+    public static <A, B> Fn1<Map<A, B>, Map<A, B>> mergeMaps(Supplier<Map<A, B>> mSupplier, Semigroup<B> semigroup, Map<A, B> x) {
+        return mergeMaps(mSupplier, semigroup).apply(x);
+    }
+
+    public static <A, B> Map<A, B> mergeMaps(Supplier<Map<A, B>> mSupplier, Semigroup<B> semigroup, Map<A, B> x, Map<A, B> y) {
+        return mergeMaps(mSupplier, semigroup, x).apply(y);
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/monoid/builtin/MergeMapsTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/monoid/builtin/MergeMapsTest.java
@@ -1,0 +1,43 @@
+package com.jnape.palatable.lambda.monoid.builtin;
+
+import com.jnape.palatable.lambda.monoid.Monoid;
+import com.jnape.palatable.lambda.semigroup.Semigroup;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.ToMap.toMap;
+import static com.jnape.palatable.lambda.monoid.builtin.MergeMaps.mergeMaps;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MergeMapsTest {
+    private static final Semigroup<Integer> ADD = (x, y) -> x + y;
+    private Monoid<Map<String, Integer>> merge;
+
+    @Before
+    public void setUp() {
+        merge = mergeMaps(HashMap::new, ADD);
+    }
+
+    @Test
+    public void identity() {
+        assertTrue(merge.identity().isEmpty());
+    }
+
+    @Test
+    public void monoid() {
+        assertEquals(singletonMap("foo", 1), merge.apply(emptyMap(), singletonMap("foo", 1)));
+        assertEquals(singletonMap("foo", 1), merge.apply(singletonMap("foo", 1), emptyMap()));
+        assertEquals(singletonMap("foo", 2),
+                merge.apply(singletonMap("foo", 1), singletonMap("foo", 1)));
+        assertEquals(toMap(HashMap::new, asList(tuple("foo", 1), tuple("bar", 1))),
+                merge.apply(singletonMap("foo", 1), singletonMap("bar", 1)));
+    }
+}


### PR DESCRIPTION
- Given a Map supplier and a Semigroup over B get a Monoid<Map<A, B>>

Not super crazy about the name or the MapSupplier implicitly having to be empty in order to be lawful.

I can also add Javadocs if everything else looks fine.