### PR TITLE
Splice function for Iterables

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn4/Splice.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn4/Splice.java
@@ -1,0 +1,52 @@
+package com.jnape.palatable.lambda.functions.builtin.fn4;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.Fn3;
+import com.jnape.palatable.lambda.functions.Fn4;
+import com.jnape.palatable.lambda.internal.iteration.SplicingIterator;
+
+/**
+ * Return an {@link Iterable} that is the result of splicing all of the elements of an {@link Iterable} into
+ * another {@link Iterable} at a given position, optionally replacing a number of elements in the original {@link Iterable}.
+ * <p>
+ * If <code>startIndex</code> exceeds the size of <code>original</code>, <code>replacement</code> is concatenated to the end.
+ * <p>
+ * Note that <code>splice</code> is equivalent to, but more efficient than
+ * <code>take(startIndex, original) ++ replacement ++ drop(startIndex + replaceCount, original)</code>.
+ *
+ * @param <A> The Iterable element type
+ */
+public final class Splice<A> implements Fn4<Integer, Integer, Iterable<A>, Iterable<A>, Iterable<A>> {
+
+    private static final Splice<?> INSTANCE = new Splice<>();
+
+    private Splice() {
+    }
+
+    @Override
+    public Iterable<A> checkedApply(Integer startIndex, Integer replaceCount, Iterable<A> replacement, Iterable<A> original) {
+        return () -> new SplicingIterator<>(startIndex, replaceCount, replacement.iterator(), original.iterator());
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> Splice<A> splice() {
+        return (Splice<A>) INSTANCE;
+    }
+
+    public static <A> Fn3<Integer, Iterable<A>, Iterable<A>, Iterable<A>> splice(Integer startIndex) {
+        return Splice.<A>splice().apply(startIndex);
+    }
+
+    public static <A> Fn2<Iterable<A>, Iterable<A>, Iterable<A>> splice(Integer startIndex, Integer replaceCount) {
+        return Splice.<A>splice(startIndex).apply(replaceCount);
+    }
+
+    public static <A> Fn1<Iterable<A>, Iterable<A>> splice(Integer startIndex, Integer replaceCount, Iterable<A> replacement) {
+        return Splice.<A>splice(startIndex, replaceCount).apply(replacement);
+    }
+
+    public static <A> Iterable<A> splice(Integer startIndex, Integer replaceCount, Iterable<A> replacement, Iterable<A> original) {
+        return Splice.splice(startIndex, replaceCount, replacement).apply(original);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/internal/iteration/SplicingIterator.java
+++ b/src/main/java/com/jnape/palatable/lambda/internal/iteration/SplicingIterator.java
@@ -1,0 +1,75 @@
+package com.jnape.palatable.lambda.internal.iteration;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static java.lang.Math.max;
+
+public final class SplicingIterator<A> extends ImmutableIterator<A> {
+    private enum Phase {FRONT, SPLICE, BACK}
+
+    private final Iterator<A> original;
+    private final Iterator<A> replacement;
+    private final int startIndex;
+    private int replaceCount;
+    private Phase phase;
+    private int currentIndex;
+    private A nextElement;
+
+    public SplicingIterator(int startIndex, int replaceCount, Iterator<A> replacement, Iterator<A> original) {
+        this.original = original;
+        this.replacement = replacement;
+        this.startIndex = max(0, startIndex);
+        this.replaceCount = max(0, replaceCount);
+        this.phase = Phase.FRONT;
+        this.currentIndex = 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (nextElement == null) {
+            nextElement = readNextElement();
+        }
+        return nextElement != null;
+    }
+
+    @Override
+    public A next() {
+        if (hasNext()) {
+            A result = nextElement;
+            nextElement = null;
+            return result;
+        } else {
+            throw new NoSuchElementException();
+        }
+    }
+
+    private A readNextElement() {
+        if (phase == Phase.FRONT) {
+            if (currentIndex < startIndex && original.hasNext()) {
+                currentIndex++;
+                return original.next();
+            } else {
+                phase = Phase.SPLICE;
+            }
+        }
+
+        if (phase == Phase.SPLICE) {
+            if (replacement.hasNext()) {
+                return replacement.next();
+            } else {
+                while (original.hasNext() && replaceCount > 0) {
+                    original.next();
+                    replaceCount--;
+                }
+                phase = Phase.BACK;
+            }
+        }
+
+        if (original.hasNext()) {
+            return original.next();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn4/SpliceTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn4/SpliceTest.java
@@ -1,0 +1,106 @@
+package com.jnape.palatable.lambda.functions.builtin.fn4;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.traitor.annotations.TestTraits;
+import com.jnape.palatable.traitor.runners.Traits;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import testsupport.traits.EmptyIterableSupport;
+import testsupport.traits.FiniteIteration;
+import testsupport.traits.ImmutableIteration;
+import testsupport.traits.Laziness;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+import static com.jnape.palatable.lambda.functions.builtin.fn4.Splice.splice;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertThat;
+import static testsupport.matchers.IterableMatcher.iterates;
+
+@RunWith(Traits.class)
+public class SpliceTest {
+
+    @TestTraits({FiniteIteration.class, EmptyIterableSupport.class, ImmutableIteration.class, Laziness.class})
+    public Fn1<Iterable<Object>, Iterable<Object>> createTestSubject() {
+        return splice(5, 3, asList(100, 200, 300, 400, 500));
+    }
+
+    @Test
+    public void spliceIsAttachedToEndIfOriginalIsNotLongEnough() {
+        assertThat(splice(100, 0, asList(4, 5, 6), asList(1, 2, 3)),
+                iterates(1, 2, 3, 4, 5, 6));
+    }
+
+    @Test
+    public void splicingIntoEmptyIterableEqualsReplacement() {
+        assertThat(splice(100, 100, asList(1, 2, 3), emptyList()),
+                iterates(1, 2, 3));
+    }
+
+    @Test
+    public void splicesEmptyWithoutReplacing() {
+        assertThat(splice(3, 0, emptyList(), asList(1, 2, 3, 4, 5)),
+                iterates(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void spliceEmptyAndReplaces() {
+        assertThat(splice(2, 2, emptyList(), asList(1, 2, 3, 4, 5)),
+                iterates(1, 2, 5));
+    }
+
+    @Test
+    public void splicesOntoFrontWithoutReplacing() {
+        assertThat(splice(0, 0, asList(100, 200, 300), asList(1, 2, 3, 4, 5, 6, 7, 8)),
+                iterates(100, 200, 300, 1, 2, 3, 4, 5, 6, 7, 8));
+    }
+
+    @Test
+    public void splicesOntoFrontAndReplaces() {
+        assertThat(splice(0, 5, asList(100, 200, 300), asList(1, 2, 3, 4, 5, 6, 7, 8)),
+                iterates(100, 200, 300, 6, 7, 8));
+    }
+
+    @Test
+    public void splicesIntoMiddleWithoutReplacing() {
+        assertThat(splice(3, 0, asList(100, 200, 300), asList(1, 2, 3, 4, 5, 6, 7, 8)),
+                iterates(1, 2, 3, 100, 200, 300, 4, 5, 6, 7, 8));
+    }
+
+    @Test
+    public void splicesIntoMiddleAndReplaces() {
+        assertThat(splice(3, 3, asList(100, 200, 300), asList(1, 2, 3, 4, 5, 6, 7, 8)),
+                iterates(1, 2, 3, 100, 200, 300, 7, 8));
+    }
+
+    @Test
+    public void splicesOntoEndWithoutReplacing() {
+        assertThat(splice(0, 0, asList(100, 200, 300), asList(1, 2, 3, 4, 5, 6, 7, 8)),
+                iterates(100, 200, 300, 1, 2, 3, 4, 5, 6, 7, 8));
+    }
+
+    @Test
+    public void spliceReplacesEntireOriginal() {
+        assertThat(splice(0, 100, asList(100, 200, 300), asList(1, 2, 3, 4, 5, 6, 7, 8)),
+                iterates(100, 200, 300));
+    }
+
+    @Test
+    public void spliceInfiniteIntoFiniteOriginal() {
+        assertThat(take(10, splice(5, 0, repeat(100), asList(1, 2, 3, 4, 5, 6, 7, 8))),
+                iterates(1, 2, 3, 4, 5, 100, 100, 100, 100, 100));
+    }
+
+    @Test
+    public void spliceFiniteIntoInfiniteOriginal() {
+        assertThat(take(10, splice(3, 0, asList(1, 2, 3), repeat(100))),
+                iterates(100, 100, 100, 1, 2, 3, 100, 100, 100, 100));
+    }
+
+    @Test
+    public void spliceInfiniteIntoInfiniteOriginal() {
+        assertThat(take(10, splice(3, 0, repeat(100), repeat(1))),
+                iterates(1, 1, 1, 100, 100, 100, 100, 100, 100, 100));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/SplicingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/SplicingIteratorTest.java
@@ -1,0 +1,179 @@
+package com.jnape.palatable.lambda.internal.iteration;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyIterator;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class SplicingIteratorTest {
+
+    @Test
+    public void hasNextBeforeTakingAnyElements() {
+        List<Integer> original = asList(1, 2, 3, 4, 5, 6, 7, 8);
+        List<Integer> replacement = asList(100, 200, 300);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(2, 2, replacement.iterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+    }
+
+    @Test
+    public void doesNotHaveNextIfTakenEnoughElements() {
+        List<Integer> original = asList(1, 2, 3, 4, 5, 6, 7, 8);
+        List<Integer> replacement = asList(100, 200, 300);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(2, 5, replacement.iterator(), original.iterator());
+        splicingIterator.next();
+        splicingIterator.next();
+        splicingIterator.next();
+        splicingIterator.next();
+        splicingIterator.next();
+        splicingIterator.next();
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void emptyOriginal() {
+        List<Integer> replacement = asList(1, 2, 3);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(1000, 2000, replacement.iterator(), emptyIterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(1));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(2));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(3));
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void ontoFrontWithoutReplacing() {
+        List<Integer> original = asList(1, 2, 3);
+        List<Integer> replacement = asList(100, 200);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(0, 0, replacement.iterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(100));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(200));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(1));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(2));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(3));
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void ontoFrontWithReplacing() {
+        List<Integer> original = asList(1, 2, 3);
+        List<Integer> replacement = asList(100, 200);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(0, 2, replacement.iterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(100));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(200));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(3));
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void intoMiddleWithoutReplacing() {
+        List<Integer> original = asList(1, 2, 3);
+        List<Integer> replacement = asList(100, 200);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(1, 0, replacement.iterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(1));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(100));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(200));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(2));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(3));
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void intoMiddleWithReplacing() {
+        List<Integer> original = asList(1, 2, 3);
+        List<Integer> replacement = asList(100, 200);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(1, 1, replacement.iterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(1));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(100));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(200));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(3));
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void intoMiddleReplacingWithEmpty() {
+        List<Integer> original = asList(1, 2, 3);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(1, 1, emptyIterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(1));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(3));
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void ontoEndWithoutReplacing() {
+        List<Integer> original = asList(1, 2, 3);
+        List<Integer> replacement = asList(100, 200);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(1000, 0, replacement.iterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(1));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(2));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(3));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(100));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(200));
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void ontoEndWithReplacing() {
+        List<Integer> original = asList(1, 2, 3);
+        List<Integer> replacement = asList(100, 200);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(2, 1000, replacement.iterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(1));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(2));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(100));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(200));
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void replacingEntireOriginal() {
+        List<Integer> original = asList(1, 2, 3);
+        List<Integer> replacement = asList(100, 200);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(0, 1000, replacement.iterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(100));
+        assertThat(splicingIterator.hasNext(), is(true));
+        assertThat(splicingIterator.next(), is(200));
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+    @Test
+    public void replacingEntireOriginalWithEmpty() {
+        List<Integer> original = asList(1, 2, 3);
+        SplicingIterator<Integer> splicingIterator = new SplicingIterator<>(0, 1000, emptyIterator(), original.iterator());
+        assertThat(splicingIterator.hasNext(), is(false));
+    }
+
+}


### PR DESCRIPTION
This is a function for splicing the elements of one Iterable into another at a given position.  The spliced elements can optionally replace elements in the original as well.