### PR TITLE
Adding AutoBracket, an AutoClosable constrained Bracket

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/AutoBracket.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/AutoBracket.java
@@ -1,0 +1,48 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.builtin.fn3.Bracket;
+import com.jnape.palatable.lambda.io.IO;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.Bracket.bracket;
+import static com.jnape.palatable.lambda.io.IO.io;
+
+/**
+ * Given an {@link IO} yielding some {@link AutoCloseable} type <code>A</code> and a kleisli arrow from that type to a
+ * new {@link IO} of type <code>B</code>, attempt to provision the <code>A</code>, applying the body operation if
+ * provisioning was successful and ensuring that {@link AutoCloseable#close} is called regardless of whether the body
+ * succeeds or fails.
+ * <p>
+ * This is the canonical {@link Bracket bracketing} operation for {@link AutoCloseable AutoCloseables}.
+ *
+ * @param <A> the initial {@link AutoCloseable} value type to map and clean up
+ * @param <B> the resulting type
+ * @see Bracket
+ */
+public final class AutoBracket<A extends AutoCloseable, B> implements
+        Fn2<IO<A>, Fn1<? super A, ? extends IO<B>>, IO<B>> {
+
+    private static final AutoBracket<?, ?> INSTANCE = new AutoBracket<>();
+
+    private AutoBracket() {
+    }
+
+    @Override
+    public IO<B> checkedApply(IO<A> io, Fn1<? super A, ? extends IO<B>> bodyIO) {
+        return bracket(io, a -> io(a::close), bodyIO);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A extends AutoCloseable, B> AutoBracket<A, B> autoBracket() {
+        return (AutoBracket<A, B>) INSTANCE;
+    }
+
+    public static <A extends AutoCloseable, B> Fn1<Fn1<? super A, ? extends IO<B>>, IO<B>> autoBracket(IO<A> io) {
+        return AutoBracket.<A, B>autoBracket().apply(io);
+    }
+
+    public static <A extends AutoCloseable, B> IO<B> autoBracket(IO<A> io, Fn1<? super A, ? extends IO<B>> bodyIO) {
+        return AutoBracket.<A, B>autoBracket(io).apply(bodyIO);
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AutoBracketTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AutoBracketTest.java
@@ -1,0 +1,48 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Unit;
+import com.jnape.palatable.lambda.io.IO;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.AutoBracket.autoBracket;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static testsupport.matchers.IOMatcher.throwsException;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+
+public class AutoBracketTest {
+
+    private AtomicInteger closedCounter;
+    private AutoCloseable autoCloseable;
+
+    @Before
+    public void setUp() {
+        closedCounter = new AtomicInteger(0);
+        autoCloseable = closedCounter::incrementAndGet;
+    }
+
+    @Test
+    public void closeWhenDone() {
+        IO<Integer> bracketed = autoBracket(io(autoCloseable), closeable -> io(1));
+
+        assertEquals(0, closedCounter.get());
+        assertThat(bracketed, yieldsValue(equalTo(1)));
+        assertEquals(1, closedCounter.get());
+    }
+
+    @Test
+    public void closeOnException() {
+        RuntimeException cause = new RuntimeException();
+
+        IO<Unit> bracketed = autoBracket(io(autoCloseable), closeable -> IO.throwing(cause));
+
+        assertEquals(0, closedCounter.get());
+        assertThat(bracketed, throwsException(equalTo(cause)));
+        assertEquals(1, closedCounter.get());
+    }
+}


### PR DESCRIPTION
AutoBracket constrains the allocated resource as an AutoClosable. This allows the destruction of the resource to provide the necessary deallocation IO to call close on the AutoClosable interface. This is analogous to using try-with-resources where close is automatically after the try statement is complete.

Unlike try-with-resources, this does not allow you to allocate multiple resources to be cleaned up, unless they are collected in an aggregating AutoClosable.

```
try(Resource1 resource1 = new Resource1(); Resource2 resource2 = new Resource2()) {
}
```

Bracket operates the same way. Would be curious to know the canonical way to handle the multiple resources case.

Since AutoClosables are a very common type of resource to use with Bracket, this provides some extra sugar so instead of this:

```
IO<Integer> bracketed = bracket(
    io(() -> connectToDatabase()), 
    databaseConnection -> io(databaseConnection::close),
    databaseConnection -> io(() -> queryDatabase(databaseConnection));
```

We can remove the close boilerplate.

```
IO<Integer> autoBracketed = autoBracket(
    io(() -> connectToDatabase()), 
    databaseConnection -> io(() -> queryDatabase(databaseConnection));
```
