### PR TITLE
Add utility functions for interoperability with java.util.Comparator

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/CmpEqBy.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/CmpEqBy.java
@@ -6,7 +6,9 @@ import com.jnape.palatable.lambda.functions.builtin.fn2.CmpEq;
 import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
 import com.jnape.palatable.lambda.functions.specialized.Predicate;
 
+import static com.jnape.palatable.lambda.functions.builtin.fn3.CmpEqWith.cmpEqWith;
 import static com.jnape.palatable.lambda.functions.specialized.Predicate.predicate;
+import static java.util.Comparator.comparing;
 
 /**
  * Given a mapping function from some type <code>A</code> to some {@link Comparable} type <code>B</code> and two values
@@ -16,6 +18,7 @@ import static com.jnape.palatable.lambda.functions.specialized.Predicate.predica
  * @param <A> the value type
  * @param <B> the mapped comparison type
  * @see CmpEq
+ * @see CmpEqWith
  * @see LTBy
  * @see GTBy
  */
@@ -28,7 +31,7 @@ public final class CmpEqBy<A, B extends Comparable<B>> implements Fn3<Fn1<? supe
 
     @Override
     public Boolean checkedApply(Fn1<? super A, ? extends B> compareFn, A x, A y) {
-        return compareFn.apply(x).compareTo(compareFn.apply(y)) == 0;
+        return cmpEqWith(comparing(compareFn.toFunction()), x, y);
     }
 
     @Override

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/CmpEqWith.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/CmpEqWith.java
@@ -1,0 +1,62 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import com.jnape.palatable.lambda.functions.Fn3;
+import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
+import com.jnape.palatable.lambda.functions.specialized.Predicate;
+
+import java.util.Comparator;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.Compare.compare;
+import static com.jnape.palatable.lambda.functions.ordering.ComparisonRelation.equal;
+import static com.jnape.palatable.lambda.functions.specialized.Predicate.predicate;
+
+/**
+ * Given a {@link Comparator} from some type <code>A</code> and two values of type <code>A</code>, return <code>true</code>
+ * if the first value is strictly equal to the second value (according to {@link Comparator#compare(A, A)}
+ * otherwise, return false.
+ *
+ * @param <A> the value type
+ * @see CmpEqBy
+ * @see LTBy
+ * @see GTBy
+ * @see Compare
+ */
+public final class CmpEqWith<A> implements Fn3<Comparator<A>, A, A, Boolean> {
+
+    private static final CmpEqWith<?> INSTANCE = new CmpEqWith<>();
+
+    private CmpEqWith() {
+    }
+
+    @Override
+    public BiPredicate<A, A> apply(Comparator<A> compareFn) {
+        return Fn3.super.apply(compareFn)::apply;
+    }
+
+    @Override
+    public Predicate<A> apply(Comparator<A> compareFn, A x) {
+        return predicate(Fn3.super.apply(compareFn, x));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> CmpEqWith<A> cmpEqWith() {
+        return (CmpEqWith<A>) INSTANCE;
+    }
+
+    public static <A> BiPredicate<A, A> cmpEqWith(Comparator<A> comparator) {
+        return CmpEqWith.<A>cmpEqWith().apply(comparator);
+    }
+
+    public static <A> Predicate<A> cmpEqWith(Comparator<A> comparator, A x) {
+        return CmpEqWith.cmpEqWith(comparator).apply(x);
+    }
+
+    public static <A> Boolean cmpEqWith(Comparator<A> comparator, A x, A y) {
+        return cmpEqWith(comparator, x).apply(y);
+    }
+
+    @Override
+    public Boolean checkedApply(Comparator<A> comparator, A a, A a2) {
+        return compare(comparator, a, a2).equals(equal());
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/Compare.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/Compare.java
@@ -1,0 +1,56 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.Fn3;
+import com.jnape.palatable.lambda.functions.ordering.ComparisonRelation;
+
+import java.util.Comparator;
+
+/**
+ * Given a {@link Comparator} from some type <code>A</code> and two values of type <code>A</code>, return a
+ * {@link ComparisonRelation} of the first value with reference to the second value (according to {@link Comparator#compare(A, A)}.
+ * The order of parameters is flipped with respect to {@link Comparator#compare(A, A)} for more idiomatic partial application.
+ *
+ * <p>
+ * Example:
+ * <pre>
+ * {@code
+ *  Compare.compare(naturalOrder(), 1, 2); // ComparisonRelation.GreaterThan
+ *  Compare.compare(naturalOrder(), 2, 1); // ComparisonRelation.LessThan
+ *  Compare.compare(naturalOrder(), 1, 1); // ComparisonRelation.Equal
+ * }
+ * </pre>
+ * </p>
+ *
+ * @param <A> the value type
+ * @see Comparator
+ * @see Compare
+ */
+public final class Compare<A> implements Fn3<Comparator<A>, A, A, ComparisonRelation> {
+    private static final Compare<?> INSTANCE = new Compare<>();
+
+    private Compare() { }
+
+    @Override
+    public ComparisonRelation checkedApply(Comparator<A> aComparator, A a, A a2) throws Throwable {
+        return ComparisonRelation.fromInt(aComparator.compare(a2, a));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> Compare<A> compare() {
+        return (Compare<A>) INSTANCE;
+    }
+
+    public static <A> Fn2<A, A, ComparisonRelation> compare(Comparator<A> comparator) {
+        return Compare.<A>compare().apply(comparator);
+    }
+
+    public static <A> Fn1<A, ComparisonRelation> compare(Comparator<A> comparator, A a) {
+        return compare(comparator).apply(a);
+    }
+
+    public static <A> ComparisonRelation compare(Comparator<A> aComparator, A a, A a2) {
+        return compare(aComparator, a).apply(a2);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTBy.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTBy.java
@@ -6,7 +6,9 @@ import com.jnape.palatable.lambda.functions.builtin.fn2.GT;
 import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
 import com.jnape.palatable.lambda.functions.specialized.Predicate;
 
+import static com.jnape.palatable.lambda.functions.builtin.fn3.GTWith.gtWith;
 import static com.jnape.palatable.lambda.functions.specialized.Predicate.predicate;
+import static java.util.Comparator.comparing;
 
 /**
  * Given a mapping function from some type <code>A</code> to some {@link Comparable} type <code>B</code> and two values
@@ -16,6 +18,7 @@ import static com.jnape.palatable.lambda.functions.specialized.Predicate.predica
  * @param <A> the value type
  * @param <B> the mapped comparison type
  * @see GT
+ * @see GTWith
  * @see LTBy
  */
 public final class GTBy<A, B extends Comparable<B>> implements Fn3<Fn1<? super A, ? extends B>, A, A, Boolean> {
@@ -27,7 +30,7 @@ public final class GTBy<A, B extends Comparable<B>> implements Fn3<Fn1<? super A
 
     @Override
     public Boolean checkedApply(Fn1<? super A, ? extends B> compareFn, A y, A x) {
-        return compareFn.apply(x).compareTo(compareFn.apply(y)) > 0;
+        return gtWith(comparing(compareFn.toFunction()), y, x);
     }
 
     @Override

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTEBy.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTEBy.java
@@ -6,8 +6,9 @@ import com.jnape.palatable.lambda.functions.builtin.fn2.GTE;
 import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
 import com.jnape.palatable.lambda.functions.specialized.Predicate;
 
-import static com.jnape.palatable.lambda.functions.builtin.fn3.CmpEqBy.cmpEqBy;
+import static com.jnape.palatable.lambda.functions.builtin.fn3.GTEWith.gteWith;
 import static com.jnape.palatable.lambda.functions.specialized.Predicate.predicate;
+import static java.util.Comparator.comparing;
 
 /**
  * Given a mapping function from some type <code>A</code> to some {@link Comparable} type <code>B</code> and two values
@@ -18,6 +19,7 @@ import static com.jnape.palatable.lambda.functions.specialized.Predicate.predica
  * @param <A> the value type
  * @param <B> the mapped comparison type
  * @see GTE
+ * @see GTEWith
  * @see LTEBy
  */
 public final class GTEBy<A, B extends Comparable<B>> implements Fn3<Fn1<? super A, ? extends B>, A, A, Boolean> {
@@ -29,7 +31,7 @@ public final class GTEBy<A, B extends Comparable<B>> implements Fn3<Fn1<? super 
 
     @Override
     public Boolean checkedApply(Fn1<? super A, ? extends B> compareFn, A y, A x) {
-        return GTBy.<A, B>gtBy(compareFn).or(cmpEqBy(compareFn)).apply(y, x);
+        return gteWith(comparing(compareFn.toFunction()), y, x);
     }
 
     @Override

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTEWith.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTEWith.java
@@ -1,0 +1,62 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import com.jnape.palatable.lambda.functions.Fn3;
+import com.jnape.palatable.lambda.functions.builtin.fn2.GTE;
+import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
+import com.jnape.palatable.lambda.functions.specialized.Predicate;
+
+import java.util.Comparator;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.LTWith.ltWith;
+import static com.jnape.palatable.lambda.functions.specialized.Predicate.predicate;
+
+/**
+ * Given a {@link Comparator} from some type <code>A</code> and two values of type <code>A</code>,
+ * return <code>true</code> if the second value is greater than or equal to the first value in
+ * terms of their mapped <code>B</code> results according to {@link Comparator#compare(A, A)};
+ * otherwise, return false.
+ *
+ * @param <A> the value type
+ * @see GTE
+ * @see GTEBy
+ * @see LTEWith
+ */
+public final class GTEWith<A> implements Fn3<Comparator<A>, A, A, Boolean> {
+
+    private static final GTEWith<?> INSTANCE = new GTEWith<>();
+
+    private GTEWith() {
+    }
+
+    @Override
+    public BiPredicate<A, A> apply(Comparator<A> compareFn) {
+        return Fn3.super.apply(compareFn)::apply;
+    }
+
+    @Override
+    public Predicate<A> apply(Comparator<A> compareFn, A x) {
+        return predicate(Fn3.super.apply(compareFn, x));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> GTEWith<A> gteWith() {
+        return (GTEWith<A>) INSTANCE;
+    }
+
+    public static <A> BiPredicate<A, A> gteWith(Comparator<A> comparator) {
+        return GTEWith.<A>gteWith().apply(comparator);
+    }
+
+    public static <A> Predicate<A> gteWith(Comparator<A> comparator, A y) {
+        return GTEWith.gteWith(comparator).apply(y);
+    }
+
+    public static <A> Boolean gteWith(Comparator<A> comparator, A y, A x) {
+        return gteWith(comparator, y).apply(x);
+    }
+
+    @Override
+    public Boolean checkedApply(Comparator<A> comparator, A a, A a2) {
+        return !ltWith(comparator, a, a2);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTWith.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTWith.java
@@ -1,0 +1,62 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import com.jnape.palatable.lambda.functions.Fn3;
+import com.jnape.palatable.lambda.functions.builtin.fn2.GT;
+import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
+import com.jnape.palatable.lambda.functions.specialized.Predicate;
+
+import java.util.Comparator;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.Compare.compare;
+import static com.jnape.palatable.lambda.functions.ordering.ComparisonRelation.greaterThan;
+import static com.jnape.palatable.lambda.functions.specialized.Predicate.predicate;
+
+/**
+ * Given a {@link Comparator} from some type <code>A</code> and two values of type <code>A</code>,
+ * return <code>true</code> if the second value is strictly greater than the first value in
+ * terms of their mapped <code>B</code> results; otherwise, return false.
+ *
+ * @param <A> the value type
+ * @see GT
+ * @see GTBy
+ * @see LTWith
+ */
+public final class GTWith<A> implements Fn3<Comparator<A>, A, A, Boolean> {
+
+    private static final GTWith<?> INSTANCE = new GTWith<>();
+
+    private GTWith() {
+    }
+
+    @Override
+    public BiPredicate<A, A> apply(Comparator<A> compareFn) {
+        return Fn3.super.apply(compareFn)::apply;
+    }
+
+    @Override
+    public Predicate<A> apply(Comparator<A> compareFn, A x) {
+        return predicate(Fn3.super.apply(compareFn, x));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> GTWith<A> gtWith() {
+        return (GTWith<A>) INSTANCE;
+    }
+
+    public static <A> BiPredicate<A, A> gtWith(Comparator<A> comparator) {
+        return GTWith.<A>gtWith().apply(comparator);
+    }
+
+    public static <A> Predicate<A> gtWith(Comparator<A> comparator, A y) {
+        return GTWith.gtWith(comparator).apply(y);
+    }
+
+    public static <A> Boolean gtWith(Comparator<A> comparator, A y, A x) {
+        return gtWith(comparator, y).apply(x);
+    }
+
+    @Override
+    public Boolean checkedApply(Comparator<A> comparator, A a, A a2) {
+        return compare(comparator, a, a2).equals(greaterThan());
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTBy.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTBy.java
@@ -6,7 +6,9 @@ import com.jnape.palatable.lambda.functions.builtin.fn2.LT;
 import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
 import com.jnape.palatable.lambda.functions.specialized.Predicate;
 
+import static com.jnape.palatable.lambda.functions.builtin.fn3.LTWith.ltWith;
 import static com.jnape.palatable.lambda.functions.specialized.Predicate.predicate;
+import static java.util.Comparator.comparing;
 
 /**
  * Given a mapping function from some type <code>A</code> to some {@link Comparable} type <code>B</code> and two values
@@ -27,7 +29,7 @@ public final class LTBy<A, B extends Comparable<B>> implements Fn3<Fn1<? super A
 
     @Override
     public Boolean checkedApply(Fn1<? super A, ? extends B> compareFn, A y, A x) {
-        return compareFn.apply(x).compareTo(compareFn.apply(y)) < 0;
+        return ltWith(comparing(compareFn.toFunction()), y, x);
     }
 
     @Override

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTEBy.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTEBy.java
@@ -6,7 +6,8 @@ import com.jnape.palatable.lambda.functions.builtin.fn2.LTE;
 import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
 import com.jnape.palatable.lambda.functions.specialized.Predicate;
 
-import static com.jnape.palatable.lambda.functions.builtin.fn3.CmpEqBy.cmpEqBy;
+import static com.jnape.palatable.lambda.functions.builtin.fn3.LTEWith.lteWith;
+import static java.util.Comparator.comparing;
 
 /**
  * Given a mapping function from some type <code>A</code> to some {@link Comparable} type <code>B</code> and two values
@@ -28,7 +29,7 @@ public final class LTEBy<A, B extends Comparable<B>> implements Fn3<Fn1<? super 
 
     @Override
     public Boolean checkedApply(Fn1<? super A, ? extends B> compareFn, A y, A x) {
-        return LTBy.<A, B>ltBy(compareFn).or(cmpEqBy(compareFn)).apply(y, x);
+        return lteWith(comparing(compareFn.toFunction()), y, x);
     }
 
     @Override

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTEWith.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTEWith.java
@@ -1,0 +1,62 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import com.jnape.palatable.lambda.functions.Fn3;
+import com.jnape.palatable.lambda.functions.builtin.fn2.LTE;
+import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
+import com.jnape.palatable.lambda.functions.specialized.Predicate;
+
+import java.util.Comparator;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.GTWith.gtWith;
+import static com.jnape.palatable.lambda.functions.specialized.Predicate.predicate;
+
+/**
+ * Given a {@link Comparator} from some type <code>A</code> and two values of type <code>A</code>,
+ * return <code>true</code> if the second value is less than or equal to the first value in
+ * terms of their mapped <code>B</code> results according to {@link Comparator#compare(A, A)};
+ * otherwise, return false.
+ *
+ * @param <A> the value type
+ * @see LTE
+ * @see LTEBy
+ * @see GTEWith
+ */
+public final class LTEWith<A> implements Fn3<Comparator<A>, A, A, Boolean> {
+
+    private static final LTEWith<?> INSTANCE = new LTEWith<>();
+
+    private LTEWith() {
+    }
+
+    @Override
+    public BiPredicate<A, A> apply(Comparator<A> compareFn) {
+        return Fn3.super.apply(compareFn)::apply;
+    }
+
+    @Override
+    public Predicate<A> apply(Comparator<A> compareFn, A x) {
+        return predicate(Fn3.super.apply(compareFn, x));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> LTEWith<A> lteWith() {
+        return (LTEWith<A>) INSTANCE;
+    }
+
+    public static <A> BiPredicate<A, A> lteWith(Comparator<A> comparator) {
+        return LTEWith.<A>lteWith().apply(comparator);
+    }
+
+    public static <A> Predicate<A> lteWith(Comparator<A> comparator, A y) {
+        return LTEWith.lteWith(comparator).apply(y);
+    }
+
+    public static <A> Boolean lteWith(Comparator<A> comparator, A y, A x) {
+        return lteWith(comparator, y).apply(x);
+    }
+
+    @Override
+    public Boolean checkedApply(Comparator<A> comparator, A a, A a2) {
+        return !gtWith(comparator, a, a2);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTWith.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTWith.java
@@ -1,0 +1,62 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import com.jnape.palatable.lambda.functions.Fn3;
+import com.jnape.palatable.lambda.functions.builtin.fn2.LT;
+import com.jnape.palatable.lambda.functions.specialized.BiPredicate;
+import com.jnape.palatable.lambda.functions.specialized.Predicate;
+
+import java.util.Comparator;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.Compare.compare;
+import static com.jnape.palatable.lambda.functions.ordering.ComparisonRelation.lessThan;
+import static com.jnape.palatable.lambda.functions.specialized.Predicate.predicate;
+
+/**
+ * Given a comparator for some type <code>A</code> and two values of type <code>A</code>,
+ * return <code>true</code> if the second value is strictly less than than the first value in
+ * terms of their mapped <code>B</code> results; otherwise, return false.
+ *
+ * @param <A> the value type
+ * @see LT
+ * @see LTBy
+ * @see GTWith
+ */
+public final class LTWith<A> implements Fn3<Comparator<A>, A, A, Boolean> {
+
+    private static final LTWith<?> INSTANCE = new LTWith<>();
+
+    private LTWith() {
+    }
+
+    @Override
+    public BiPredicate<A, A> apply(Comparator<A> compareFn) {
+        return Fn3.super.apply(compareFn)::apply;
+    }
+
+    @Override
+    public Predicate<A> apply(Comparator<A> compareFn, A x) {
+        return predicate(Fn3.super.apply(compareFn, x));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> LTWith<A> ltWith() {
+        return (LTWith<A>) INSTANCE;
+    }
+
+    public static <A> BiPredicate<A, A> ltWith(Comparator<A> comparator) {
+        return LTWith.<A>ltWith().apply(comparator);
+    }
+
+    public static <A> Predicate<A> ltWith(Comparator<A> comparator, A y) {
+        return LTWith.ltWith(comparator).apply(y);
+    }
+
+    public static <A> Boolean ltWith(Comparator<A> comparator, A y, A x) {
+        return ltWith(comparator, y).apply(x);
+    }
+
+    @Override
+    public Boolean checkedApply(Comparator<A> comparator, A a, A a2) {
+        return compare(comparator, a, a2).equals(lessThan());
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/ordering/ComparisonRelation.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/ordering/ComparisonRelation.java
@@ -1,0 +1,89 @@
+package com.jnape.palatable.lambda.functions.ordering;
+
+import com.jnape.palatable.lambda.adt.coproduct.CoProduct3;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.builtin.fn3.Compare;
+
+import java.util.Comparator;
+
+/**
+ * Specialized {@link CoProduct3} representing the possible results of a ordered comparison.
+ * Used by {@link Compare} as the result of a comparison.
+ *
+ * @see Compare
+ */
+public abstract class ComparisonRelation
+        implements CoProduct3<ComparisonRelation.LessThan, ComparisonRelation.Equal, ComparisonRelation.GreaterThan, ComparisonRelation> {
+    private ComparisonRelation() { }
+
+    /**
+     * Return a comparison relation from the result of a {@link Comparator} or {@link Comparable} result
+     *
+     * @param signifier The result of {@link Comparator#compare(Object, Object)} or {@link Comparable#compareTo(Object)}
+     * @return The intended {@link ComparisonRelation} of the signifier
+     */
+    public static ComparisonRelation fromInt(int signifier) {
+        return signifier > 0 ? greaterThan() : signifier == 0 ? equal() : lessThan();
+    }
+
+    public static GreaterThan greaterThan() {
+        return GreaterThan.INSTANCE;
+    }
+
+    public static LessThan lessThan() {
+        return LessThan.INSTANCE;
+    }
+
+    public static Equal equal() {
+        return Equal.INSTANCE;
+    }
+
+    public final static class LessThan extends ComparisonRelation {
+        private static final LessThan INSTANCE = new LessThan();
+
+        private LessThan() {
+        }
+
+        @Override
+        public String toString() {
+            return "LessThan";
+        }
+
+        @Override
+        public <R> R match(Fn1<? super LessThan, ? extends R> aFn, Fn1<? super Equal, ? extends R> bFn, Fn1<? super GreaterThan, ? extends R> cFn) {
+            return aFn.apply(this);
+        }
+    }
+
+    public final static class Equal extends ComparisonRelation {
+        private static final Equal INSTANCE = new Equal();
+
+        private Equal() {
+        }
+
+        public String toString() {
+            return "Equal";
+        }
+
+        @Override
+        public <R> R match(Fn1<? super LessThan, ? extends R> aFn, Fn1<? super Equal, ? extends R> bFn, Fn1<? super GreaterThan, ? extends R> cFn) {
+            return bFn.apply(this);
+        }
+    }
+
+    public final static class GreaterThan extends ComparisonRelation {
+        private static final GreaterThan INSTANCE = new GreaterThan();
+
+        private GreaterThan() { }
+
+        @Override
+        public String toString() {
+            return "GreaterThan";
+        }
+
+        @Override
+        public <R> R match(Fn1<? super LessThan, ? extends R> aFn, Fn1<? super Equal, ? extends R> bFn, Fn1<? super GreaterThan, ? extends R> cFn) {
+            return cFn.apply(this);
+        }
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/MaxBy.java
+++ b/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/MaxBy.java
@@ -18,6 +18,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn3.LTBy.ltBy;
  * @param <A> the value type
  * @param <B> the mapped comparison type
  * @see Max
+ * @see MaxWith
  * @see MinBy
  */
 public final class MaxBy<A, B extends Comparable<B>> implements SemigroupFactory<Fn1<? super A, ? extends B>, A> {

--- a/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/MaxWith.java
+++ b/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/MaxWith.java
@@ -1,0 +1,52 @@
+package com.jnape.palatable.lambda.semigroup.builtin;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.specialized.SemigroupFactory;
+import com.jnape.palatable.lambda.semigroup.Semigroup;
+
+import java.util.Comparator;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.LTWith.ltWith;
+
+/**
+ * Given a comparator for some type <code>A</code>, produce a {@link Semigroup} over <code>A</code> that chooses
+ * between two values <code>x</code> and <code>y</code> via the following rules:
+ * <ul>
+ * <li>If <code>x</code> is strictly less than <code>y</code> in terms of <code>B</code>, return <code>y</code></li>
+ * <li>Otherwise, return <code>x</code></li>
+ * </ul>
+ *
+ * @param <A> the value type
+ * @see Max
+ * @see MaxBy
+ * @see MinWith
+ */
+public final class MaxWith<A> implements SemigroupFactory<Comparator<A>, A> {
+
+    private static final MaxWith<?> INSTANCE = new MaxWith<>();
+
+    private MaxWith() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> MaxWith<A> maxWith() {
+        return (MaxWith<A>) INSTANCE;
+    }
+
+    public static <A> Semigroup<A> maxWith(Comparator<A> compareFn) {
+        return MaxWith.<A>maxWith().apply(compareFn);
+    }
+
+    public static <A> Fn1<A, A> maxWith(Comparator<A> compareFn, A x) {
+        return MaxWith.maxWith(compareFn).apply(x);
+    }
+
+    public static <A> A maxWith(Comparator<A> compareFn, A x, A y) {
+        return maxWith(compareFn, x).apply(y);
+    }
+
+    @Override
+    public Semigroup<A> checkedApply(Comparator<A> comparator) {
+        return (x, y) -> ltWith(comparator, y, x) ? y : x;
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/MinWith.java
+++ b/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/MinWith.java
@@ -1,0 +1,52 @@
+package com.jnape.palatable.lambda.semigroup.builtin;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.specialized.SemigroupFactory;
+import com.jnape.palatable.lambda.semigroup.Semigroup;
+
+import java.util.Comparator;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.GTWith.gtWith;
+
+/**
+ * Given a comparator for some type <code>A</code>, produce a {@link Semigroup} over <code>A</code> that chooses
+ * between two values <code>x</code> and <code>y</code> via the following rules:
+ * <ul>
+ * <li>If <code>x</code> is strictly greater than <code>y</code> in terms of <code>B</code>, return <code>y</code></li>
+ * <li>Otherwise, return <code>x</code></li>
+ * </ul>
+ *
+ * @param <A> the value type
+ * @see Min
+ * @see MinBy
+ * @see MaxBy
+ */
+public final class MinWith<A> implements SemigroupFactory<Comparator<A>, A> {
+
+    private static final MinWith<?> INSTANCE = new MinWith<>();
+
+    private MinWith() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> MinWith<A> minWith() {
+        return (MinWith<A>) INSTANCE;
+    }
+
+    public static <A> Semigroup<A> minWith(Comparator<A> compareFn) {
+        return MinWith.<A>minWith().apply(compareFn);
+    }
+
+    public static <A> Fn1<A, A> minWith(Comparator<A> compareFn, A x) {
+        return MinWith.minWith(compareFn).apply(x);
+    }
+
+    public static <A> A minWith(Comparator<A> compareFn, A x, A y) {
+        return minWith(compareFn, x).apply(y);
+    }
+
+    @Override
+    public Semigroup<A> checkedApply(Comparator<A> comparator) {
+        return (x, y) -> gtWith(comparator, y, x) ? y : x;
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/CmpEqWithTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/CmpEqWithTest.java
@@ -1,0 +1,19 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
+import static com.jnape.palatable.lambda.functions.builtin.fn3.CmpEqBy.cmpEqBy;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CmpEqWithTest {
+    @Test
+    public void comparisons() {
+        assertTrue(cmpEqBy(id(), 1, 1));
+        assertFalse(cmpEqBy(id(), 1, 2));
+        assertFalse(cmpEqBy(id(), 2, 1));
+
+        assertTrue(cmpEqBy(String::length, "b", "a"));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/CompareTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/CompareTest.java
@@ -1,0 +1,19 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.Compare.compare;
+import static com.jnape.palatable.lambda.functions.ordering.ComparisonRelation.equal;
+import static com.jnape.palatable.lambda.functions.ordering.ComparisonRelation.greaterThan;
+import static com.jnape.palatable.lambda.functions.ordering.ComparisonRelation.lessThan;
+import static java.util.Comparator.naturalOrder;
+import static org.junit.Assert.assertEquals;
+
+public class CompareTest {
+    @Test
+    public void comparisons() {
+        assertEquals(equal(), compare(naturalOrder(), 1, 1));
+        assertEquals(lessThan(), compare(naturalOrder(), 2, 1));
+        assertEquals(greaterThan(), compare(naturalOrder(), 1, 2));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTEWithTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTEWithTest.java
@@ -1,0 +1,21 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.GTEWith.gteWith;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GTEWithTest {
+    @Test
+    public void comparisons() {
+        assertTrue(gteWith(naturalOrder(), 1, 2));
+        assertTrue(gteWith(naturalOrder(), 1, 1));
+        assertFalse(gteWith(naturalOrder(), 2, 1));
+
+        assertTrue(gteWith(comparing(String::length), "b", "ab"));
+        assertTrue(gteWith(comparing(String::length), "bc", "ab"));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTWithTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/GTWithTest.java
@@ -1,0 +1,20 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.GTWith.gtWith;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class GTWithTest {
+    @Test
+    public void comparisons() {
+        assertTrue(gtWith(naturalOrder(), 1, 2));
+        assertFalse(gtWith(naturalOrder(), 1, 1));
+        assertFalse(gtWith(naturalOrder(), 2, 1));
+
+        assertTrue(gtWith(comparing(String::length), "bb", "aaa"));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTEWithTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTEWithTest.java
@@ -1,0 +1,21 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.LTEWith.lteWith;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LTEWithTest {
+    @Test
+    public void comparisons() {
+        assertTrue(lteWith(naturalOrder(), 2, 1));
+        assertTrue(lteWith(naturalOrder(), 1, 1));
+        assertFalse(lteWith(naturalOrder(), 1, 2));
+
+        assertTrue(lteWith(comparing(String::length), "ab", "b"));
+        assertTrue(lteWith(comparing(String::length), "ab", "bc"));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTWithTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/LTWithTest.java
@@ -1,0 +1,20 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn3.LTWith.ltWith;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LTWithTest {
+    @Test
+    public void comparisons() {
+        assertTrue(ltWith(naturalOrder(), 2, 1));
+        assertFalse(ltWith(naturalOrder(), 1, 1));
+        assertFalse(ltWith(naturalOrder(), 1, 2));
+
+        assertTrue(ltWith(comparing(String::length), "ab", "b"));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/ordering/ComparisonRelationTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/ordering/ComparisonRelationTest.java
@@ -1,0 +1,23 @@
+package com.jnape.palatable.lambda.functions.ordering;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.ordering.ComparisonRelation.equal;
+import static com.jnape.palatable.lambda.functions.ordering.ComparisonRelation.greaterThan;
+import static com.jnape.palatable.lambda.functions.ordering.ComparisonRelation.lessThan;
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Integer.MIN_VALUE;
+import static org.junit.Assert.assertEquals;
+
+public class ComparisonRelationTest {
+    @Test
+    public void fromInt() {
+        assertEquals(greaterThan(), ComparisonRelation.fromInt(1));
+        assertEquals(greaterThan(), ComparisonRelation.fromInt(MAX_VALUE));
+
+        assertEquals(equal(), ComparisonRelation.fromInt(0));
+
+        assertEquals(lessThan(), ComparisonRelation.fromInt(-1));
+        assertEquals(lessThan(), ComparisonRelation.fromInt(MIN_VALUE));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/MaxWithTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/MaxWithTest.java
@@ -1,0 +1,21 @@
+package com.jnape.palatable.lambda.semigroup.builtin;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.semigroup.builtin.MaxWith.maxWith;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static org.junit.Assert.assertEquals;
+
+public class MaxWithTest {
+    @Test
+    public void semigroup() {
+        assertEquals((Integer) 1, maxWith(naturalOrder(), 1, 0));
+        assertEquals((Integer) 1, maxWith(naturalOrder(), 1, 1));
+        assertEquals((Integer) 2, maxWith(naturalOrder(), 1, 2));
+
+        assertEquals("ab", maxWith(comparing(String::length), "ab", "a"));
+        assertEquals("ab", maxWith(comparing(String::length), "ab", "cd"));
+        assertEquals("bc", maxWith(comparing(String::length), "a", "bc"));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/MinWithTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/MinWithTest.java
@@ -1,0 +1,21 @@
+package com.jnape.palatable.lambda.semigroup.builtin;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.semigroup.builtin.MinWith.minWith;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static org.junit.Assert.assertEquals;
+
+public class MinWithTest {
+    @Test
+    public void semigroup() {
+        assertEquals((Integer) 1, minWith(naturalOrder(), 1, 2));
+        assertEquals((Integer) 1, minWith(naturalOrder(), 1, 1));
+        assertEquals((Integer) 0, minWith(naturalOrder(), 1, 0));
+
+        assertEquals("a", minWith(comparing(String::length), "a", "ab"));
+        assertEquals("ab", minWith(comparing(String::length), "ab", "cd"));
+        assertEquals("c", minWith(comparing(String::length), "ab", "c"));
+    }
+}


### PR DESCRIPTION
For https://github.com/palatable/lambda/issues/77

- Add ComparisonRelation to encapsulate Comparator/Comparable#compare semantics
- Add Compare to abstract over Comparator#compare using ComparisonRelation
- Add comparator compatible functions (CmpEqWith, GTEWith, GTWith, LTEWith, LTWith)