### PR TITLE
Added StateMatcher and StateTMatcher

### DIFF
--- a/src/test/java/com/jnape/palatable/lambda/matchers/StateTMatcherTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/matchers/StateTMatcherTest.java
@@ -1,0 +1,55 @@
+package com.jnape.palatable.lambda.matchers;
+
+import com.jnape.palatable.lambda.adt.Either;
+import com.jnape.palatable.lambda.monad.transformer.builtin.StateT;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.jnape.palatable.lambda.adt.Either.left;
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.StateT.stateT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+import static testsupport.matchers.LeftMatcher.isLeftThat;
+import static testsupport.matchers.RightMatcher.isRightThat;
+import static testsupport.matchers.StateTMatcher.*;
+
+public class StateTMatcherTest {
+
+    @Test
+    public void stateTevalsTThatMatcher() {
+        assertThat(stateT(Either.right(1)),
+                hasEvalTThat("0", isRightThat(equalTo(1))));
+    }
+
+    @Test
+    public void stateTexecsTThatMatcher() {
+        assertThat(stateT(Either.right(1)),
+                hasExecTThat(left("0"), isRightThat(isLeftThat(equalTo("0")))));
+    }
+
+    @Test
+    public void stateTisStateTThatWithTwoMatchers() {
+        assertThat(stateT(Either.right(1)),
+                isStateTThat(left("0"), isRightThat(equalTo(1)), isRightThat(isLeftThat(equalTo("0")))));
+    }
+
+    @Test
+    public void stateTisStateTThatWithOneTupleMatcher() {
+        assertThat(stateT(Either.right(1)),
+                isStateTThat(left("0"), isRightThat(equalTo(tuple(1, left("0"))))));
+    }
+
+    @Test
+    public void onlyRunsStateOnceWithTupleMatcher() {
+        AtomicInteger count = new AtomicInteger(0);
+
+        assertThat(StateT.gets(s -> io(count::incrementAndGet)),
+                isStateTThat(0, yieldsValue(equalTo(tuple(1, 0)))));
+        assertEquals(1, count.get());
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/monad/transformer/builtin/StateTTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/monad/transformer/builtin/StateTTest.java
@@ -1,6 +1,5 @@
 package com.jnape.palatable.lambda.monad.transformer.builtin;
 
-import com.jnape.palatable.lambda.adt.Maybe;
 import com.jnape.palatable.lambda.adt.Unit;
 import com.jnape.palatable.lambda.adt.hlist.Tuple2;
 import com.jnape.palatable.lambda.functor.builtin.Identity;
@@ -8,13 +7,7 @@ import com.jnape.palatable.traitor.annotations.TestTraits;
 import com.jnape.palatable.traitor.runners.Traits;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import testsupport.traits.ApplicativeLaws;
-import testsupport.traits.Equivalence;
-import testsupport.traits.FunctorLaws;
-import testsupport.traits.MonadLaws;
-import testsupport.traits.MonadReaderLaws;
-import testsupport.traits.MonadRecLaws;
-import testsupport.traits.MonadWriterLaws;
+import testsupport.traits.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,18 +19,19 @@ import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
 import static com.jnape.palatable.lambda.optics.functions.Set.set;
 import static com.jnape.palatable.lambda.optics.lenses.ListLens.elementAt;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static testsupport.matchers.StateTMatcher.*;
 import static testsupport.traits.Equivalence.equivalence;
 
 @RunWith(Traits.class)
 public class StateTTest {
 
     @TestTraits({FunctorLaws.class,
-                 ApplicativeLaws.class,
-                 MonadLaws.class,
-                 MonadRecLaws.class,
-                 MonadReaderLaws.class,
-                 MonadWriterLaws.class})
+            ApplicativeLaws.class,
+            MonadLaws.class,
+            MonadRecLaws.class,
+            MonadReaderLaws.class,
+            MonadWriterLaws.class})
     public Equivalence<StateT<String, Identity<?>, Integer>> testReader() {
         return equivalence(StateT.gets(s -> new Identity<>(s.length())), s -> s.runStateT("foo"));
     }
@@ -47,85 +41,80 @@ public class StateTTest {
         StateT<String, Identity<?>, Integer> stateT =
                 StateT.stateT(str -> new Identity<>(tuple(str.length(), str + "_")));
 
-        assertEquals(new Identity<>("__"), stateT.execT("_"));
-        assertEquals(new Identity<>(1), stateT.evalT("_"));
+        assertThat(stateT, hasExecT("_", new Identity<>("__")));
+        assertThat(stateT, hasEvalT("_", new Identity<>(1)));
     }
 
     @Test
     public void mapStateT() {
         StateT<String, Identity<?>, Integer> stateT =
                 StateT.stateT(str -> new Identity<>(tuple(str.length(), str + "_")));
-        assertEquals(just(tuple(4, "ABC_")),
-                     stateT.mapStateT(id -> id.<Identity<Tuple2<Integer, String>>>coerce()
-                             .runIdentity()
-                             .into((x, str) -> just(tuple(x + 1, str.toUpperCase()))))
-                             .<Maybe<Tuple2<Integer, String>>>runStateT("abc"));
+
+        assertThat(stateT.mapStateT(id -> id.<Identity<Tuple2<Integer, String>>>coerce()
+                        .runIdentity()
+                        .into((x, str) -> just(tuple(x + 1, str.toUpperCase())))),
+                isStateT("abc", just(tuple(4, "ABC_"))));
     }
 
     @Test
     public void zipping() {
-        Tuple2<Unit, List<String>> result = StateT.<List<String>, Identity<?>>modify(
+        StateT<List<String>, Identity<?>, Unit> result = StateT.<List<String>, Identity<?>>modify(
                 s -> new Identity<>(set(elementAt(s.size()), just("one"), s)))
-                .discardL(StateT.modify(s -> new Identity<>(set(elementAt(s.size()), just("two"), s))))
-                .<Identity<Tuple2<Unit, List<String>>>>runStateT(new ArrayList<>())
-                .runIdentity();
+                .discardL(StateT.modify(s -> new Identity<>(set(elementAt(s.size()), just("two"), s))));
 
-        assertEquals(tuple(UNIT, asList("one", "two")),
-                     result);
+        assertThat(result,
+            isStateT(new ArrayList<>(), new Identity<>(tuple(UNIT, asList("one", "two")))));
     }
 
     @Test
     public void withStateT() {
         StateT<String, Identity<?>, Integer> stateT =
                 StateT.stateT(str -> new Identity<>(tuple(str.length(), str + "_")));
-        assertEquals(new Identity<>(tuple(3, "ABC_")),
-                     stateT.withStateT(str -> new Identity<>(str.toUpperCase())).runStateT("abc"));
+        assertThat(stateT.withStateT(str -> new Identity<>(str.toUpperCase())),
+                isStateT("abc", new Identity<>(tuple(3, "ABC_"))));
     }
 
     @Test
     public void get() {
-        assertEquals(new Identity<>(tuple("state", "state")),
-                     StateT.<String, Identity<?>>get(pureIdentity()).runStateT("state"));
+        assertThat(StateT.get(pureIdentity()),
+                isStateT("state", new Identity<>(tuple("state", "state"))));
     }
 
     @Test
     public void gets() {
-        assertEquals(new Identity<>(tuple(5, "state")),
-                     StateT.<String, Identity<?>, Integer>gets(s -> new Identity<>(s.length())).runStateT("state"));
+        assertThat(StateT.gets(s -> new Identity<>(s.length())),
+                isStateT("state", new Identity<>(tuple(5, "state"))));
     }
 
     @Test
     public void put() {
-        assertEquals(new Identity<>(tuple(UNIT, 1)), StateT.put(new Identity<>(1)).runStateT(0));
+        assertThat(StateT.put(new Identity<>(1)),
+                isStateT(0, new Identity<>(tuple(UNIT, 1))));
     }
 
     @Test
     public void modify() {
-        assertEquals(new Identity<>(tuple(UNIT, 1)),
-                     StateT.<Integer, Identity<?>>modify(x -> new Identity<>(x + 1)).runStateT(0));
+        assertThat(StateT.modify(x -> new Identity<>(x + 1)),
+                isStateT(0, new Identity<>(tuple(UNIT, 1))));
     }
 
     @Test
     public void stateT() {
-        assertEquals(new Identity<>(tuple(0, "_")),
-                     StateT.<String, Identity<?>, Integer>stateT(new Identity<>(0)).runStateT("_"));
-        assertEquals(new Identity<>(tuple(1, "_1")),
-                     StateT.<String, Identity<?>, Integer>stateT(s -> new Identity<>(tuple(s.length(), s + "1")))
-                             .runStateT("_"));
+        assertThat(StateT.stateT(new Identity<>(0)),
+                isStateT("_", new Identity<>(tuple(0, "_"))));
+        assertThat(StateT.stateT(s -> new Identity<>(tuple(s.length(), s + "1"))),
+                isStateT("_", new Identity<>(tuple(1, "_1"))));
     }
 
     @Test
     public void staticPure() {
-        assertEquals(new Identity<>(tuple(1, "foo")),
-                     StateT.<String, Identity<?>>pureStateT(pureIdentity())
-                             .<Integer, StateT<String, Identity<?>, Integer>>apply(1)
-                             .<Identity<Tuple2<Integer, String>>>runStateT("foo"));
+        assertThat(StateT.<String, Identity<?>>pureStateT(pureIdentity()).apply(1),
+                isStateT("foo", new Identity<>(tuple(1, "foo"))));
     }
 
     @Test
     public void staticLift() {
-        assertEquals(new Identity<>(tuple(1, "foo")),
-                     StateT.<String>liftStateT().<Integer, Identity<?>, StateT<String, Identity<?>, Integer>>apply(new Identity<>(1))
-                             .<Identity<Tuple2<Integer, String>>>runStateT("foo"));
+        assertThat(StateT.<String>liftStateT().apply(new Identity<>(1)),
+                isStateT("foo", new Identity<>(tuple(1, "foo"))));
     }
 }

--- a/src/test/java/testsupport/matchers/StateMatcher.java
+++ b/src/test/java/testsupport/matchers/StateMatcher.java
@@ -1,0 +1,83 @@
+package testsupport.matchers;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functor.builtin.State;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.adt.Unit.UNIT;
+import static com.jnape.palatable.lambda.functions.Effect.noop;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static org.hamcrest.Matchers.equalTo;
+
+public class StateMatcher<S, A> extends TypeSafeMatcher<State<S, A>> {
+    private final S initialState;
+    private final Maybe<Matcher<? super S>> stateMatcher;
+    private final Maybe<Matcher<? super A>> valueMatcher;
+
+    private StateMatcher(S initialState, Maybe<Matcher<? super A>> valueMatcher, Maybe<Matcher<? super S>> stateMatcher) {
+        this.initialState = initialState;
+        this.stateMatcher = stateMatcher;
+        this.valueMatcher = valueMatcher;
+    }
+
+    @Override
+    protected boolean matchesSafely(State<S, A> item) {
+        Tuple2<A, S> run = item.run(initialState);
+        return stateMatcher.match(constantly(true), matcher -> matcher.matches(run._2())) &&
+                valueMatcher.match(constantly(true), matcher -> matcher.matches(run._1()));
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        stateMatcher.match(noop(),
+                matcher -> io(() -> matcher.describeTo(description.appendText("State matching "))))
+                .discardL(valueMatcher.match(noop(),
+                        matcher -> io(() -> matcher.describeTo(description.appendText("Value matching ")))))
+                .unsafePerformIO();
+    }
+
+    @Override
+    protected void describeMismatchSafely(State<S, A> item, Description mismatchDescription) {
+        io(() -> item.run(initialState))
+                .flatMap(as ->
+                        stateMatcher.fmap(matcher -> io(() -> {
+                            mismatchDescription.appendText("state matching ");
+                            mismatchDescription.appendValue(as._2());
+                        })).orElse(io(UNIT))
+                                .flatMap(constantly(valueMatcher.fmap(matcher -> io(() -> {
+                                    mismatchDescription.appendText("value matching ");
+                                    mismatchDescription.appendValue(as._1());
+                                })).orElse(io(UNIT)))))
+                .unsafePerformIO();
+    }
+
+    public static <S, A> StateMatcher<S, A> isStateThat(S initialState, Matcher<? super A> valueMatcher, Matcher<? super S> stateMatcher) {
+        return new StateMatcher<>(initialState, just(valueMatcher), just(stateMatcher));
+    }
+
+    public static <S, A> StateMatcher<S, A> isState(S initialState, A value, S state) {
+        return isStateThat(initialState, equalTo(value), equalTo(state));
+    }
+
+    public static <S, A> StateMatcher<S, A> hasExecThat(S initialState, Matcher<? super S> stateMatcher) {
+        return new StateMatcher<>(initialState, nothing(), just(stateMatcher));
+    }
+
+    public static <S, A> StateMatcher<S, A> hasExec(S initialState, S state) {
+        return hasExecThat(initialState, equalTo(state));
+    }
+
+    public static <S, A> StateMatcher<S, A> hasEvalThat(S initialState, Matcher<? super A> valueMatcher) {
+        return new StateMatcher<>(initialState, just(valueMatcher), nothing());
+    }
+
+    public static <S, A> StateMatcher<S, A> hasEval(S initialState, A value) {
+        return hasEvalThat(initialState, equalTo(value));
+    }
+}

--- a/src/test/java/testsupport/matchers/StateTMatcher.java
+++ b/src/test/java/testsupport/matchers/StateTMatcher.java
@@ -1,0 +1,111 @@
+package testsupport.matchers;
+
+import com.jnape.palatable.lambda.adt.Either;
+import com.jnape.palatable.lambda.adt.These;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.StateT;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import static com.jnape.palatable.lambda.adt.Either.left;
+import static com.jnape.palatable.lambda.adt.Either.right;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static org.hamcrest.Matchers.equalTo;
+
+public class StateTMatcher<S, M extends MonadRec<?, M>, A, MA extends MonadRec<A, M>, MS extends MonadRec<S, M>, MTS extends MonadRec<Tuple2<A, S>, M>> extends TypeSafeMatcher<StateT<S, M, A>> {
+    private final S initialState;
+
+    private final Either<Matcher<? super MTS>, These<Matcher<? super MA>, Matcher<? super MS>>> matcher;
+
+    private StateTMatcher(S initialState, These<Matcher<? super MA>, Matcher<? super MS>> matchers) {
+        this.initialState = initialState;
+        this.matcher = right(matchers);
+    }
+
+    private StateTMatcher(S initialState, Matcher<? super MTS> matcher) {
+        this.initialState = initialState;
+        this.matcher = left(matcher);
+    }
+
+    @Override
+    protected boolean matchesSafely(StateT<S, M, A> item) {
+        MonadRec<Tuple2<A, S>, M> ran = item.runStateT(initialState);
+        return matcher.match(bothMatcher -> bothMatcher.matches(ran),
+                theseMatchers -> theseMatchers.match(a -> a.matches(ran.fmap(Tuple2::_1)),
+                        b -> b.matches(ran.fmap(Tuple2::_2)),
+                        ab -> ab._1().matches(ran.fmap(Tuple2::_1)) && ab._2().matches(ran.fmap(Tuple2::_2))));
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        matcher.match(bothMatcher -> io(() -> bothMatcher.describeTo(description.appendText("Value and state matching "))),
+                theseMatchers -> theseMatchers.match(a -> io(() -> a.describeTo(description.appendText("Value matching "))),
+                        b -> io(() -> b.describeTo(description.appendText("State matching "))),
+                        ab -> io(() -> {
+                            ab._1().describeTo(description.appendText("Value matching "));
+                            ab._2().describeTo(description.appendText(" and state matching "));
+                        })))
+                .unsafePerformIO();
+    }
+
+    @Override
+    protected void describeMismatchSafely(StateT<S, M, A> item, Description mismatchDescription) {
+        MonadRec<Tuple2<A, S>, M> ran = item.runStateT(initialState);
+
+        matcher.match(bothMatcher -> io(() -> {
+                    mismatchDescription.appendText("value and state matching ");
+                    bothMatcher.describeMismatch(ran, mismatchDescription);
+                }),
+                theseMatchers -> theseMatchers.match(a -> io(() -> {
+                            mismatchDescription.appendText("value matching ");
+                            a.describeMismatch(ran.fmap(Tuple2::_1), mismatchDescription);
+                        }),
+                        b -> io(() -> {
+                            mismatchDescription.appendText("state matching ");
+                            b.describeMismatch(ran.fmap(Tuple2::_2), mismatchDescription);
+                        }),
+                        ab -> io(() -> {
+                            mismatchDescription.appendText("value matching ");
+                            ab._1().describeMismatch(ran.fmap(Tuple2::_1), mismatchDescription);
+                            mismatchDescription.appendText(" and state matching ");
+                            ab._2().describeMismatch(ran.fmap(Tuple2::_2), mismatchDescription);
+                        })))
+                .unsafePerformIO();
+    }
+
+    public static <S, M extends MonadRec<?, M>, A, MA extends MonadRec<A, M>, MS extends MonadRec<S, M>, MTS extends MonadRec<Tuple2<A, S>, M>> StateTMatcher<S, M, A, MA, MS, MTS> isStateTThat(S initialState, Matcher<? super MTS> bothMatcher) {
+        return new StateTMatcher<>(initialState, bothMatcher);
+    }
+
+    public static <S, M extends MonadRec<?, M>, A, MA extends MonadRec<A, M>, MS extends MonadRec<S, M>, MTS extends MonadRec<Tuple2<A, S>, M>> StateTMatcher<S, M, A, MA, MS, MTS> isStateT(S initialState, MTS both) {
+        return isStateTThat(initialState, equalTo(both));
+    }
+
+    // Note: This constructor will run both matchers, which can run effects twice
+    public static <S, M extends MonadRec<?, M>, A, MA extends MonadRec<A, M>, MS extends MonadRec<S, M>, MTS extends MonadRec<Tuple2<A, S>, M>> StateTMatcher<S, M, A, MA, MS, MTS> isStateTThat(S initialState, Matcher<? super MA> valueMatcher, Matcher<? super MS> stateMatcher) {
+        return new StateTMatcher<>(initialState, These.both(valueMatcher, stateMatcher));
+    }
+
+    // Note: This constructor will run both matchers, which can run effects twice
+    public static <S, M extends MonadRec<?, M>, A, MA extends MonadRec<A, M>, MS extends MonadRec<S, M>, MTS extends MonadRec<Tuple2<A, S>, M>> StateTMatcher<S, M, A, MA, MS, MTS> isStateT(S initialState, MA value, MS state) {
+        return isStateTThat(initialState, equalTo(value), equalTo(state));
+    }
+
+    public static <S, M extends MonadRec<?, M>, A, MA extends MonadRec<A, M>, MS extends MonadRec<S, M>, MTS extends MonadRec<Tuple2<A, S>, M>> StateTMatcher<S, M, A, MA, MS, MTS> hasExecTThat(S initialState, Matcher<? super MS> stateMatcher) {
+        return new StateTMatcher<>(initialState, These.b(stateMatcher));
+    }
+
+    public static <S, M extends MonadRec<?, M>, A, MA extends MonadRec<A, M>, MS extends MonadRec<S, M>, MTS extends MonadRec<Tuple2<A, S>, M>> StateTMatcher<S, M, A, MA, MS, MTS> hasExecT(S initialState, MS state) {
+        return hasExecTThat(initialState, equalTo(state));
+    }
+
+    public static <S, M extends MonadRec<?, M>, A, MA extends MonadRec<A, M>, MS extends MonadRec<S, M>, MTS extends MonadRec<Tuple2<A, S>, M>> StateTMatcher<S, M, A, MA, MS, MTS> hasEvalTThat(S initialState, Matcher<? super MA> valueMatcher) {
+        return new StateTMatcher<>(initialState, These.a(valueMatcher));
+    }
+
+    public static <S, M extends MonadRec<?, M>, A, MA extends MonadRec<A, M>, MS extends MonadRec<S, M>, MTS extends MonadRec<Tuple2<A, S>, M>> StateTMatcher<S, M, A, MA, MS, MTS> hasEvalT(S initialState, MA value) {
+        return hasEvalTThat(initialState, equalTo(value));
+    }
+}


### PR DESCRIPTION
Thoughts:

* Do we want a separate StateMatcher from StateTMatcher?  The logic and the API for the former is simpler if we keep it separate, since we can simply `run` the initial state and match on the resulting tuple without worrying about repeating monadic effects.

* Not completely happy with names for exec & eval matchers - advice welcome.

* Would there be a way to combine, say, two `IO` matchers (say, `IO<A>` and `IO<S>`) to work on a tuple `IO<Tuple2<A,S>>` without running the effects twice?  I suspect not, since, for example, `yieldValue` calls `unsafePerformIO` itself, so there's no way of having two separate `yieldValue` matchers without having each of them separately running the `IO`.