### PR TITLE
Mark JUnit as test scope; upgrade JUnit to 4.13; upgrade Traitor to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </developers>
 
     <properties>
-        <traitor.version>1.3.0</traitor.version>
+        <traitor.version>1.4.0</traitor.version>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
         <hamcrest.version>2.1</hamcrest.version>
         <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
@@ -63,6 +63,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>4.13</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/test/java/com/jnape/palatable/lambda/adt/EitherTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/adt/EitherTest.java
@@ -4,9 +4,7 @@ import com.jnape.palatable.lambda.functions.Fn2;
 import com.jnape.palatable.traitor.annotations.TestTraits;
 import com.jnape.palatable.traitor.framework.Subjects;
 import com.jnape.palatable.traitor.runners.Traits;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import testsupport.traits.ApplicativeLaws;
 import testsupport.traits.BifunctorLaws;
@@ -27,14 +25,12 @@ import static com.jnape.palatable.lambda.functor.builtin.Lazy.lazy;
 import static com.jnape.palatable.traitor.framework.Subjects.subjects;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static testsupport.assertion.MonadErrorAssert.assertLaws;
 
 @RunWith(Traits.class)
 public class EitherTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @TestTraits({
             FunctorLaws.class,
@@ -86,10 +82,11 @@ public class EitherTest {
 
         assertThat(right.orThrow(IllegalStateException::new), is(1));
 
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("foo");
-
-        left.orThrow(IllegalStateException::new);
+        assertThrows(
+            "foo",
+            IllegalStateException.class,
+            () -> left.orThrow(IllegalStateException::new)
+        );
     }
 
     @Test

--- a/src/test/java/com/jnape/palatable/lambda/adt/TryTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/adt/TryTest.java
@@ -3,9 +3,7 @@ package com.jnape.palatable.lambda.adt;
 import com.jnape.palatable.traitor.annotations.TestTraits;
 import com.jnape.palatable.traitor.framework.Subjects;
 import com.jnape.palatable.traitor.runners.Traits;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import testsupport.traits.ApplicativeLaws;
 import testsupport.traits.FunctorLaws;
@@ -33,11 +31,11 @@ import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
 import static com.jnape.palatable.lambda.functor.builtin.Lazy.lazy;
 import static com.jnape.palatable.traitor.framework.Subjects.subjects;
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static testsupport.assertion.MonadErrorAssert.assertLaws;
@@ -45,8 +43,6 @@ import static testsupport.matchers.EitherMatcher.isLeftThat;
 
 @RunWith(Traits.class)
 public class TryTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @TestTraits({FunctorLaws.class, ApplicativeLaws.class, MonadLaws.class, TraversableLaws.class, MonadRecLaws.class})
     public Subjects<Try<Integer>> testSubject() {
@@ -137,12 +133,20 @@ public class TryTest {
     }
 
     @Test
-    public void orThrow() throws Throwable {
+    public void orThrow() {
         assertEquals((Integer) 1, trying(() -> 1).orThrow());
 
         Throwable expected = new Exception("expected");
-        thrown.expect(equalTo(expected));
-        trying(() -> {throw expected;}).orThrow();
+
+        Try<Object> trying = trying(() -> {
+            throw expected;
+        });
+
+        assertThrows(
+            "expected",
+            Exception.class,
+            trying::orThrow
+        );
     }
 
     @Test

--- a/src/test/java/com/jnape/palatable/lambda/adt/hlist/HListTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/adt/hlist/HListTest.java
@@ -4,7 +4,12 @@ import org.junit.Test;
 
 import static com.jnape.palatable.lambda.adt.hlist.HList.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class HListTest {
 
@@ -48,7 +53,7 @@ public class HListTest {
     }
 
     @Test
-    @SuppressWarnings({"EqualsWithItself", "EqualsBetweenInconvertibleTypes"})
+    @SuppressWarnings({"EqualsWithItself", "EqualsBetweenInconvertibleTypes", "SimplifiableJUnitAssertion"})
     public void equality() {
         assertTrue(nil().equals(nil()));
         assertTrue(cons(1, nil()).equals(cons(1, nil())));

--- a/src/test/java/com/jnape/palatable/lambda/adt/hmap/HMapTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/adt/hmap/HMapTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/EffectTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/EffectTest.java
@@ -20,7 +20,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IOMatcher.yieldsValue;
 
 public class EffectTest {

--- a/src/test/java/com/jnape/palatable/lambda/functions/Fn2Test.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/Fn2Test.java
@@ -9,7 +9,7 @@ import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Fn2Test {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/Fn3Test.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/Fn3Test.java
@@ -6,7 +6,7 @@ import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.Fn3.fn3;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Fn3Test {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/Fn4Test.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/Fn4Test.java
@@ -6,7 +6,7 @@ import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.Fn4.fn4;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Fn4Test {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/Fn5Test.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/Fn5Test.java
@@ -6,7 +6,7 @@ import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.Fn5.fn5;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Fn5Test {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/Fn6Test.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/Fn6Test.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Fn6Test {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/Fn7Test.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/Fn7Test.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Fn7Test {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/Fn8Test.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/Fn8Test.java
@@ -6,7 +6,7 @@ import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.Fn8.fn8;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Fn8Test {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CatMaybesTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CatMaybesTest.java
@@ -11,7 +11,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CoalesceTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CoalesceTest.java
@@ -7,7 +7,7 @@ import static com.jnape.palatable.lambda.adt.Either.right;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Coalesce.coalesce;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.EitherMatcher.isLeftThat;
 import static testsupport.matchers.EitherMatcher.isRightThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/ConstantlyTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/ConstantlyTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConstantlyTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CycleTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CycleTest.java
@@ -10,7 +10,7 @@ import testsupport.traits.Laziness;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Cycle.cycle;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/DistinctTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/DistinctTest.java
@@ -12,7 +12,7 @@ import testsupport.traits.Laziness;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Distinct.distinct;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/FlattenTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/FlattenTest.java
@@ -19,7 +19,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/IdTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/IdTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class IdTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/InitTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/InitTest.java
@@ -15,7 +15,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn1.Init.init;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/InitsTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/InitsTest.java
@@ -15,7 +15,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn1.Inits.inits;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/MagnetizeTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/MagnetizeTest.java
@@ -14,7 +14,7 @@ import testsupport.traits.Laziness;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Magnetize.magnetize;
 import static java.util.Arrays.asList;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/RepeatTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/RepeatTest.java
@@ -10,7 +10,7 @@ import testsupport.traits.Laziness;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/ReverseTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/ReverseTest.java
@@ -13,7 +13,7 @@ import java.util.Iterator;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Reverse.reverse;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/SortTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/SortTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Sort.sort;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 public class SortTest {

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/TailTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/TailTest.java
@@ -13,7 +13,7 @@ import testsupport.traits.Laziness;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Tail.tail;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/TailsTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/TailsTest.java
@@ -20,7 +20,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/UnconsTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/UnconsTest.java
@@ -12,7 +12,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn1.Uncons.uncons;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AllTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AllTest.java
@@ -12,7 +12,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.All.all;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(Traits.class)
 public class AllTest {

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AlterTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AlterTest.java
@@ -10,7 +10,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IOMatcher.yieldsValue;
 
 public class AlterTest {

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AnyTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AnyTest.java
@@ -12,7 +12,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Any.any;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(Traits.class)
 public class AnyTest {

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AutoBracketTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/AutoBracketTest.java
@@ -11,7 +11,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.AutoBracket.autoB
 import static com.jnape.palatable.lambda.io.IO.io;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IOMatcher.throwsException;
 import static testsupport.matchers.IOMatcher.yieldsValue;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/CartesianProductTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/CartesianProductTest.java
@@ -14,7 +14,7 @@ import testsupport.traits.Laziness;
 import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.CartesianProduct.cartesianProduct;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ConsTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ConsTest.java
@@ -13,7 +13,7 @@ import testsupport.traits.Laziness;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Cons.cons;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DifferenceTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DifferenceTest.java
@@ -15,7 +15,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.Difference.differ
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropTest.java
@@ -17,7 +17,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.Drop.drop;
 import static com.jnape.palatable.lambda.functions.builtin.fn3.Times.times;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.DropWhile.dropWhile;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/FilterTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/FilterTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Filter.filter;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/InGroupsOfTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/InGroupsOfTest.java
@@ -13,7 +13,7 @@ import testsupport.traits.Laziness;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.InGroupsOf.inGroupsOf;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/IntersperseTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/IntersperseTest.java
@@ -13,7 +13,7 @@ import testsupport.traits.Laziness;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Intersperse.intersperse;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/IterateTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/IterateTest.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Iterate.iterate;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/MagnetizeByTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/MagnetizeByTest.java
@@ -21,7 +21,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/MapTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/MapTest.java
@@ -14,7 +14,7 @@ import testsupport.traits.Laziness;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Map.map;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/PartitionTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/PartitionTest.java
@@ -22,7 +22,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.Partition.partiti
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
 import static com.jnape.palatable.traitor.framework.Subjects.subjects;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/PrependAllTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/PrependAllTest.java
@@ -14,7 +14,7 @@ import testsupport.traits.Laziness;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.PrependAll.prependAll;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReduceLeftTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReduceLeftTest.java
@@ -8,7 +8,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.ReduceLeft.reduce
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.functions.ExplainFold.explainFold;
 
 public class ReduceLeftTest {

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReduceRightTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReduceRightTest.java
@@ -8,7 +8,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.ReduceRight.reduc
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.functions.ExplainFold.explainFold;
 
 public class ReduceRightTest {

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReplicateTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReplicateTest.java
@@ -3,7 +3,7 @@ package com.jnape.palatable.lambda.functions.builtin.fn2;
 import org.junit.Test;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Replicate.replicate;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SequenceTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SequenceTest.java
@@ -16,7 +16,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.Sequence.sequence
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 public class SequenceTest {

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SlideTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SlideTest.java
@@ -18,7 +18,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SnocTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SnocTest.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Snoc.snoc;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SortByTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SortByTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.SortBy.sortBy;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SpanTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/SpanTest.java
@@ -17,7 +17,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.Eq.eq;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Span.span;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeTest.java
@@ -13,7 +13,7 @@ import testsupport.traits.Laziness;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeWhileTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeWhileTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeWhile.takeWhile;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/Tupler2Test.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/Tupler2Test.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Tupler2.tupler;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Tupler2Test {
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/UnfoldrTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/UnfoldrTest.java
@@ -15,7 +15,7 @@ import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Unfoldr.unfoldr;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/UntilTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/UntilTest.java
@@ -8,7 +8,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.consta
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Until.until;
 import static com.jnape.palatable.lambda.io.IO.io;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IOMatcher.yieldsValue;
 
 public class UntilTest {

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ZipTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ZipTest.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Zip.zip;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/BracketTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/BracketTest.java
@@ -12,7 +12,7 @@ import static com.jnape.palatable.lambda.io.IO.io;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IOMatcher.throwsException;
 import static testsupport.matchers.IOMatcher.yieldsValue;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/FoldLeftTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/FoldLeftTest.java
@@ -11,7 +11,7 @@ import static com.jnape.palatable.lambda.functions.builtin.fn3.FoldLeft.foldLeft
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.functions.ExplainFold.explainFold;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/FoldRightTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/FoldRightTest.java
@@ -15,7 +15,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.Constants.STACK_EXPLODING_NUMBER;
 import static testsupport.functions.ExplainFold.explainFold;
 

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/ScanLeftTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/ScanLeftTest.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn3.ScanLeft.scanLeft;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/TimesTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/TimesTest.java
@@ -1,17 +1,14 @@
 package com.jnape.palatable.lambda.functions.builtin.fn3;
 
 import com.jnape.palatable.lambda.functions.Fn1;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
 import static com.jnape.palatable.lambda.functions.builtin.fn3.Times.times;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class TimesTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void accumulatesFunctionNTimes() {
@@ -27,10 +24,11 @@ public class TimesTest {
 
     @Test
     public void lessThanZeroIsIllegal() {
-        thrown.expect(IllegalStateException.class);
-        thrown.expectMessage("n must not be less than 0");
-
-        times(-1, id(), 1);
+        assertThrows(
+            "n must not be less than 0",
+            IllegalStateException.class,
+            () -> times(-1, id(), 1)
+        );
     }
 
     @Test

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/ZipWithTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/ZipWithTest.java
@@ -14,7 +14,7 @@ import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Zip.zip;
 import static com.jnape.palatable.lambda.functions.builtin.fn3.ZipWith.zipWith;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 @RunWith(Traits.class)

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn4/RateLimitTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn4/RateLimitTest.java
@@ -24,7 +24,7 @@ import static java.time.Clock.systemUTC;
 import static java.time.Duration.ZERO;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 import static testsupport.matchers.RateLimitedIterationMatcher.iteratesAccordingToRateLimit;
 
@@ -34,7 +34,7 @@ public class RateLimitTest {
     private InstantRecordingClock clock;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         clock = new InstantRecordingClock(systemUTC());
     }
 
@@ -62,7 +62,7 @@ public class RateLimitTest {
     }
 
     @Test(timeout = 100, expected = IterationInterruptedException.class)
-    public void rateLimitingDelayIsInterruptible() throws InterruptedException {
+    public void rateLimitingDelayIsInterruptible() {
         Thread         testThread = Thread.currentThread();
         CountDownLatch latch      = new CountDownLatch(1);
         new Thread(() -> {

--- a/src/test/java/com/jnape/palatable/lambda/functions/specialized/BiPredicateTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/specialized/BiPredicateTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class BiPredicateTest {

--- a/src/test/java/com/jnape/palatable/lambda/functor/BifunctorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functor/BifunctorTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BifunctorTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/functor/ProfunctorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functor/ProfunctorTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ProfunctorTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/functor/builtin/StateTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functor/builtin/StateTest.java
@@ -16,7 +16,7 @@ import static com.jnape.palatable.lambda.adt.Unit.UNIT;
 import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.StateMatcher.whenEvaluated;
 import static testsupport.matchers.StateMatcher.whenExecuted;
 import static testsupport.matchers.StateMatcher.whenRun;

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/CyclicIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/CyclicIteratorTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CyclicIteratorTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/DroppingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/DroppingIteratorTest.java
@@ -9,7 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Iterator;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.Mocking.mockIteratorToHaveValues;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/FilteringIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/FilteringIteratorTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static java.lang.Character.toUpperCase;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FilteringIteratorTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/GroupingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/GroupingIteratorTest.java
@@ -9,7 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Iterator;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.Mocking.mockIteratorToHaveValues;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/InfiniteIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/InfiniteIteratorTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.exceptions.OutOfScopeException.outOfScope;
 
 public class InfiniteIteratorTest {

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/MappingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/MappingIteratorTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MappingIteratorTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIteratorTest.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.Mocking.mockIteratorToHaveValues;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/PredicatedTakingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/PredicatedTakingIteratorTest.java
@@ -8,7 +8,7 @@ import java.util.NoSuchElementException;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PredicatedTakingIteratorTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/PrependingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/PrependingIteratorTest.java
@@ -1,8 +1,6 @@
 package com.jnape.palatable.lambda.internal.iteration;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.NoSuchElementException;
 
@@ -10,19 +8,20 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyIterator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class PrependingIteratorTest {
-
-    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void empty() {
         PrependingIterator<Integer> iterator = new PrependingIterator<>(0, emptyIterator());
         assertFalse(iterator.hasNext());
 
-        thrown.expect(NoSuchElementException.class);
-        iterator.next();
+        assertThrows(
+            NoSuchElementException.class,
+            iterator::next
+        );
     }
 
     @Test

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/ReversingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/ReversingIteratorTest.java
@@ -9,7 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Iterator;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/RewindableIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/RewindableIteratorTest.java
@@ -10,7 +10,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.Mocking.mockIteratorToHaveValues;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/TakingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/TakingIteratorTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TakingIteratorTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/UnfoldingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/UnfoldingIteratorTest.java
@@ -12,7 +12,7 @@ import static com.jnape.palatable.lambda.adt.Maybe.nothing;
 import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class UnfoldingIteratorTest {
 

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/ZippingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/ZippingIteratorTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Iterator;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/jnape/palatable/lambda/io/IOTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/io/IOTest.java
@@ -6,9 +6,7 @@ import com.jnape.palatable.lambda.adt.hlist.Tuple2;
 import com.jnape.palatable.lambda.functions.Fn1;
 import com.jnape.palatable.traitor.annotations.TestTraits;
 import com.jnape.palatable.traitor.runners.Traits;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import testsupport.traits.ApplicativeLaws;
 import testsupport.traits.Equivalence;
@@ -61,8 +59,6 @@ import static testsupport.traits.Equivalence.equivalence;
 
 @RunWith(Traits.class)
 public class IOTest {
-
-    public @Rule ExpectedException thrown = ExpectedException.none();
 
     @TestTraits({FunctorLaws.class, ApplicativeLaws.class, MonadLaws.class, MonadRecLaws.class})
     public Equivalence<IO<Integer>> testSubject() {

--- a/src/test/java/com/jnape/palatable/lambda/monad/transformer/builtin/IterateTTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/monad/transformer/builtin/IterateTTest.java
@@ -41,7 +41,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.Constants.STACK_EXPLODING_NUMBER;
 import static testsupport.matchers.IOMatcher.yieldsValue;
 import static testsupport.matchers.IterateTMatcher.*;

--- a/src/test/java/com/jnape/palatable/lambda/monad/transformer/builtin/WriterTTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/monad/transformer/builtin/WriterTTest.java
@@ -26,7 +26,7 @@ import static com.jnape.palatable.lambda.monad.transformer.builtin.WriterT.write
 import static com.jnape.palatable.lambda.monoid.builtin.Join.join;
 import static com.jnape.palatable.lambda.monoid.builtin.Trivial.trivial;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.WriterTMatcher.whenEvaluatedWith;
 import static testsupport.matchers.WriterTMatcher.whenExecutedWith;
 import static testsupport.matchers.WriterTMatcher.whenRunWith;

--- a/src/test/java/com/jnape/palatable/lambda/monoid/builtin/ConcatTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/monoid/builtin/ConcatTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static com.jnape.palatable.lambda.monoid.builtin.Concat.concat;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/monoid/builtin/RunAllTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/monoid/builtin/RunAllTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import static com.jnape.palatable.lambda.io.IO.io;
 import static com.jnape.palatable.lambda.monoid.builtin.RunAll.runAll;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IOMatcher.yieldsValue;
 
 public class RunAllTest {

--- a/src/test/java/com/jnape/palatable/lambda/monoid/builtin/UnionTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/monoid/builtin/UnionTest.java
@@ -18,7 +18,7 @@ import static com.jnape.palatable.traitor.framework.Subjects.subjects;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/optics/lenses/IterableLensTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/optics/lenses/IterableLensTest.java
@@ -16,7 +16,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/optics/lenses/MapLensTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/optics/lenses/MapLensTest.java
@@ -25,7 +25,7 @@ import static java.util.Collections.unmodifiableMap;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.assertion.LensAssert.assertLensLawfulness;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/optics/lenses/SetLensTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/optics/lenses/SetLensTest.java
@@ -10,7 +10,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.assertion.LensAssert.assertLensLawfulness;
 
 public class SetLensTest {

--- a/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/IntersectionTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/IntersectionTest.java
@@ -14,7 +14,7 @@ import static com.jnape.palatable.lambda.semigroup.builtin.Intersection.intersec
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.isEmpty;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/RunAllTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/RunAllTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static com.jnape.palatable.lambda.io.IO.io;
 import static com.jnape.palatable.lambda.semigroup.builtin.RunAll.runAll;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IOMatcher.yieldsValue;
 
 public class RunAllTest {

--- a/src/test/java/com/jnape/palatable/lambda/traversable/LambdaIterableTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/traversable/LambdaIterableTest.java
@@ -31,7 +31,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.Constants.STACK_EXPLODING_NUMBER;
 import static testsupport.matchers.IterableMatcher.iterates;
 

--- a/src/test/java/com/jnape/palatable/lambda/traversable/TraversableTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/traversable/TraversableTest.java
@@ -9,7 +9,7 @@ import static com.jnape.palatable.lambda.adt.Maybe.just;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.matchers.IterableMatcher.iterates;
 
 public class TraversableTest {

--- a/src/test/java/testsupport/traits/Laziness.java
+++ b/src/test/java/testsupport/traits/Laziness.java
@@ -3,7 +3,7 @@ package testsupport.traits;
 import com.jnape.palatable.lambda.functions.Fn1;
 import com.jnape.palatable.traitor.traits.Trait;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static testsupport.Mocking.mockIterable;
 import static testsupport.matchers.ZeroInvocationsMatcher.wasNeverInteractedWith;
 


### PR DESCRIPTION
The JUnit upgrade deprecates `ExpectedException` and `org.junit.Assert.assertThat`

A read-only internal collection broke Traitor 1.3.0, but that was already fixed in 1.4.0 so a Traitor upgrade is also included.