### PR TITLE
Builtin functions for operating on IterateT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - `Fn1#withSelf`, a static method for constructing a self-referencing `Fn1` 
 - `HNil/SingletonHList/TupleX#snoc`, a method to add a new last element (append to a tuple)
 
+### Fixed
+- `IterateT#trampolineM` now yields and stages all recursive result values, rather 
+  than prematurely terminating on the first termination result
+
 ## [5.2.0] - 2020-02-12
 
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>lambda</artifactId>
-    <version>5.3.0</version>
+    <version>5.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Lambda</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>lambda</artifactId>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.3.0</version>
     <packaging>jar</packaging>
 
     <name>Lambda</name>

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn0/NaturalNumbers.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn0/NaturalNumbers.java
@@ -1,0 +1,22 @@
+package com.jnape.palatable.lambda.functions.builtin.fn0;
+
+import com.jnape.palatable.lambda.functions.Fn0;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Iterate.iterate;
+
+public class NaturalNumbers implements Fn0<Iterable<Integer>> {
+
+    private static final NaturalNumbers INSTANCE = new NaturalNumbers();
+
+    private NaturalNumbers() {
+    }
+
+    @Override
+    public Iterable<Integer> checkedApply() {
+        return iterate(x -> x + 1, 1);
+    }
+
+    public static Iterable<Integer> naturalNumbers() {
+        return INSTANCE.apply();
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/CatMaybesM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/CatMaybesM.java
@@ -1,0 +1,40 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+
+/**
+ * Given an <code>{@link IterateT}&lt;M, {@link Maybe}&lt;A&gt;&gt;</code>, return an
+ * <code>{@link IterateT}&lt;M, A&gt;</code> of only the present values.
+ *
+ * @param <M> the IterateT effect type
+ * @param <A> the {@link Maybe} element type, as well as the resulting {@link IterateT} element type
+ */
+public class CatMaybesM<M extends MonadRec<?, M>, A> implements Fn1<IterateT<M, Maybe<A>>, IterateT<M, A>> {
+
+    private static final CatMaybesM<?, ?> INSTANCE = new CatMaybesM<>();
+
+    private CatMaybesM() {
+    }
+
+    @Override
+    public IterateT<M, A> checkedApply(IterateT<M, Maybe<A>> mas) throws Throwable {
+        return mas.flatMap((Maybe<A> ma) -> ma.match(__ -> empty(Pure.of(mas.<MonadRec<Maybe<Tuple2<Maybe<A>, IterateT<M, Maybe<A>>>>, M>>runIterateT())),
+                                                     mas::pure));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> CatMaybesM<M, A> catMaybesM() {
+        return (CatMaybesM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> IterateT<M, A> catMaybesM(IterateT<M, Maybe<A>> mas) {
+        return CatMaybesM.<M, A>catMaybesM().apply(mas);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/CycleM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/CycleM.java
@@ -1,0 +1,37 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.monad.Monad;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.RepeatM.repeatM;
+
+/**
+ * Given an <code>IterateT</code>, return an infinite <code>IterateT</code> that repeatedly cycles its elements, in
+ * order.
+ *
+ * @param <A> The IterateT element type
+ * @param <M> The IterateT effect type
+ */
+public class CycleM<M extends MonadRec<?, M>, A> implements Fn1<IterateT<M, A>, IterateT<M, A>> {
+
+    private static final CycleM<?, ?> INSTANCE = new CycleM<>();
+
+    private CycleM() {
+    }
+
+    @Override
+    public IterateT<M, A> checkedApply(IterateT<M, A> as) throws Throwable {
+        return Monad.join(repeatM(as.runIterateT().pure(as)));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> CycleM<M, A> cycleM() {
+        return (CycleM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> IterateT<M, A> cycleM(IterateT<M, A> as) {
+        return CycleM.<M, A>cycleM().apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/HeadM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/HeadM.java
@@ -1,0 +1,37 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+
+/**
+ * Retrieve the head element of an {@link IterateT}, wrapped in an {@link Maybe}. If the {@link IterateT} is empty, the
+ * result is {@link Maybe#nothing()}.
+ *
+ * @param <A> the IterateT element type
+ * @param <M> the IterateT effect type
+ */
+public class HeadM<A, M extends MonadRec<?, M>, MMA extends MonadRec<Maybe<A>, M>> implements Fn1<IterateT<M, A>, MMA> {
+
+    private static final HeadM<?, ?, ?> INSTANCE = new HeadM<>();
+
+    @Override
+    public MMA checkedApply(IterateT<M, A> as) {
+        return maybeT(as.runIterateT())
+                .fmap(Tuple2::_1)
+                .runMaybeT();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A, M extends MonadRec<?, M>, MMA extends MonadRec<Maybe<A>, M>> HeadM<A, M, MMA> headM() {
+        return (HeadM<A, M, MMA>) INSTANCE;
+    }
+
+    public static <A, M extends MonadRec<?, M>, MMA extends MonadRec<Maybe<A>, M>> MMA headM(IterateT<M, A> as) {
+        return HeadM.<A, M, MMA>headM().apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/Index.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/Index.java
@@ -1,0 +1,34 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.builtin.fn2.Zip;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn0.NaturalNumbers.naturalNumbers;
+
+/**
+ * Given an <code>{@link Iterable}&lt;A&gt;</code>, pair each element with its ordinal index.
+ *
+ * @param <A> the Iterable element type
+ */
+public class Index<A> implements Fn1<Iterable<A>, Iterable<Tuple2<Integer, A>>> {
+
+    private static final Index<?> INSTANCE = new Index<>();
+
+    private Index() {
+    }
+
+    @Override
+    public Iterable<Tuple2<Integer, A>> checkedApply(Iterable<A> as) throws Throwable {
+        return Zip.zip(naturalNumbers(), as);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> Index<A> index() {
+        return (Index<A>) INSTANCE;
+    }
+
+    public static <A> Iterable<Tuple2<Integer, A>> index(Iterable<A> as) {
+        return Index.<A>index().apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/IndexM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/IndexM.java
@@ -1,0 +1,40 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.ZipM.zipM;
+
+/**
+ * Given an <code>{@link IterateT}&lt;M, A&gt;</code>, pair each element with its ordinal index.
+ *
+ * @param <A> the IterateT element type
+ * @param <M> the IterateT effect type
+ */
+public class IndexM<M extends MonadRec<?, M>, A> implements Fn1<IterateT<M, A>, IterateT<M, Tuple2<Integer, A>>> {
+
+    private static final IndexM<?, ?> INSTANCE = new IndexM<>();
+
+    private IndexM() {
+    }
+
+    @Override
+    public IterateT<M, Tuple2<Integer, A>> checkedApply(IterateT<M, A> as) throws Throwable {
+        MonadRec<Maybe<Tuple2<A, IterateT<M, A>>>, M> unwrapped = as.runIterateT();
+        return zipM(naturalNumbersM(Pure.of(unwrapped)), as);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> IndexM<M, A> indexM() {
+        return (IndexM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> IterateT<M, Tuple2<Integer, A>> indexM(IterateT<M, A> as) {
+        return IndexM.<M, A>indexM().apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/MagnetizeM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/MagnetizeM.java
@@ -1,0 +1,36 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Eq.eq;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.MagnetizeByM.magnetizeByM;
+
+/**
+ * {@link Magnetize} an {@link IterateT} using value equality as the magnetizing function.
+ *
+ * @param <A> the IterateT element type
+ * @param <M> the IterateT effect type
+ */
+public class MagnetizeM<M extends MonadRec<?, M>, A> implements Fn1<IterateT<M, A>, IterateT<M, IterateT<M, A>>> {
+
+    private static final MagnetizeM<?, ?> INSTANCE = new MagnetizeM<>();
+
+    private MagnetizeM() {
+    }
+
+    @Override
+    public IterateT<M, IterateT<M, A>> checkedApply(IterateT<M, A> mas) throws Throwable {
+        return magnetizeByM(eq(), mas);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> MagnetizeM<M, A> magnetizeM() {
+        return (MagnetizeM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> IterateT<M, IterateT<M, A>> magnetizeM(IterateT<M, A> mas) {
+        return MagnetizeM.<M, A>magnetizeM().apply(mas);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/NaturalNumbersM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/NaturalNumbersM.java
@@ -1,0 +1,32 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.unfold;
+
+public class NaturalNumbersM<M extends MonadRec<?, M>> implements Fn1<Pure<M>, IterateT<M, Integer>> {
+
+    private static final NaturalNumbersM<?> INSTANCE = new NaturalNumbersM<>();
+
+    private NaturalNumbersM() {
+    }
+
+    @Override
+    public IterateT<M, Integer> checkedApply(Pure<M> pureM) {
+        return unfold(i -> pureM.apply(just(tuple(i, i + 1))), pureM.<Integer, MonadRec<Integer, M>>apply(1));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>> NaturalNumbersM<M> naturalNumbersM() {
+        return (NaturalNumbersM<M>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>> IterateT<M, Integer> naturalNumbersM(Pure<M> pureM) {
+        return NaturalNumbersM.<M>naturalNumbersM().apply(pureM);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/RepeatM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/RepeatM.java
@@ -1,0 +1,38 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.suspended;
+
+/**
+ * Given a value in monadic effect, return an infinite <code>IterateT</code> that repeatedly iterates that value.
+ *
+ * @param <M> the IterateT effect type
+ * @param <A> The IterateT element type
+ */
+public class RepeatM<M extends MonadRec<?, M>, A> implements Fn1<MonadRec<A, M>, IterateT<M, A>> {
+
+    private static final RepeatM<?, ?> INSTANCE = new RepeatM<>();
+
+    private RepeatM() {
+    }
+
+    @Override
+    public IterateT<M, A> checkedApply(MonadRec<A, M> ma) throws Throwable {
+        return suspended(() -> ma.fmap(a -> just(tuple(a, repeatM(ma)))), Pure.of(ma));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> RepeatM<M, A> repeatM() {
+        return (RepeatM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> IterateT<M, A> repeatM(MonadRec<A, M> ma) {
+        return RepeatM.<M, A>repeatM().apply(ma);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropM.java
@@ -1,0 +1,61 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.LT.lt;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Tupler2.tupler;
+import static com.jnape.palatable.lambda.functions.builtin.fn4.IfThenElse.ifThenElse;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.recurse;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.terminate;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.suspended;
+
+/**
+ * Lazily skip the first <code>n</code> elements from an <code>IterateT</code> by returning an <code>IterateT</code>
+ * that begins iteration after the <code>nth</code> element. If <code>n</code> is greater than or equal to the length of
+ * the <code>IterateT</code>, an empty <code>IterateT</code> is returned.
+ *
+ * @param <A> The IterateT element type
+ * @param <M> the IterateT effect type
+ * @see DropWhile
+ * @see Take
+ */
+public class DropM<A, M extends MonadRec<?, M>> implements Fn2<Integer, IterateT<M, A>, IterateT<M, A>> {
+
+    private static final DropM<?, ?> INSTANCE = new DropM<>();
+
+    @Override
+    public IterateT<M, A> checkedApply(Integer n, IterateT<M, A> as) throws Throwable {
+        MonadRec<Maybe<Tuple2<A, IterateT<M, A>>>, M> unwrapped = as.runIterateT();
+        return suspended(() -> unwrapped.fmap(tupler(0)).fmap(t -> t.fmap(unwrapped::pure))
+                                        .trampolineM(into((dropCount, remaining) -> remaining
+                                                .fmap(mta -> ifThenElse(lt(n),
+                                                                        dropped -> mta.match(__ -> terminate(nothing()),
+                                                                                             into((h, t) -> recurse(tuple(dropped + 1, t.runIterateT())))),
+                                                                        constantly(terminate(mta)),
+                                                                        dropCount)))),
+                         Pure.of(unwrapped));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A, M extends MonadRec<?, M>> DropM<A, M> dropM() {
+        return (DropM<A, M>) INSTANCE;
+    }
+
+    public static <A, M extends MonadRec<?, M>> Fn1<IterateT<M, A>, IterateT<M, A>> dropM(Integer n) {
+        return DropM.<A, M>dropM().apply(n);
+    }
+
+    public static <A, M extends MonadRec<?, M>> IterateT<M, A> dropM(Integer n, IterateT<M, A> as) {
+        return DropM.<A, M>dropM(n).apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileM.java
@@ -1,0 +1,46 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.recursion.RecursiveResult;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.terminate;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.suspended;
+
+public class DropWhileM<A, M extends MonadRec<?, M>> implements Fn2<Fn1<? super A, ? extends Boolean>, IterateT<M, A>, IterateT<M, A>> {
+
+    private static final DropWhileM<?, ?> INSTANCE = new DropWhileM<>();
+
+    @Override
+    public IterateT<M, A> checkedApply(Fn1<? super A, ? extends Boolean> predicate, IterateT<M, A> as) throws Throwable {
+        MonadRec<Maybe<Tuple2<A, IterateT<M, A>>>, M> unwrapped = as.runIterateT();
+        return suspended(
+                () -> unwrapped.trampolineM(mta -> mta
+                        .match(constantly(unwrapped.pure(terminate(nothing()))),
+                               into((A h, IterateT<M, A> t) ->
+                                            predicate.apply(h) ? t.runIterateT().fmap(RecursiveResult::recurse)
+                                                               : unwrapped.pure(terminate(mta))))),
+                Pure.of(unwrapped));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A, M extends MonadRec<?, M>> DropWhileM<A, M> dropWhileM() {
+        return (DropWhileM<A, M>) INSTANCE;
+    }
+
+    public static <A, M extends MonadRec<?, M>> Fn1<IterateT<M, A>, IterateT<M, A>> dropWhileM(Fn1<? super A, ? extends Boolean> predicate) {
+        return DropWhileM.<A, M>dropWhileM().apply(predicate);
+    }
+
+    public static <A, M extends MonadRec<?, M>> IterateT<M, A> dropWhileM(Fn1<? super A, ? extends Boolean> predicate, IterateT<M, A> as) {
+        return DropWhileM.<A, M>dropWhileM(predicate).apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/Echo.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/Echo.java
@@ -1,0 +1,41 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.builtin.fn1.Repeat;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Flatten.flatten;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Map.map;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Replicate.replicate;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+
+/**
+ * Repeat each element in an <code>Iterable</code> <code>n</code> times.
+ *
+ * @param <A> The Iterable element type
+ */
+public class Echo<A> implements Fn2<Integer, Iterable<A>, Iterable<A>> {
+
+    private static final Echo<?> INSTANCE = new Echo<>();
+
+    private Echo() {
+    }
+
+    @Override
+    public Iterable<A> checkedApply(Integer n, Iterable<A> as) throws Throwable {
+        return flatten(map(replicate(n), as));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> Echo<A> echo() {
+        return (Echo<A>) INSTANCE;
+    }
+
+    public static <A> Fn1<Iterable<A>, Iterable<A>> echo(Integer n) {
+        return Echo.<A>echo().apply(n);
+    }
+
+    public static <A> Iterable<A> echo(Integer n, Iterable<A> as) {
+        return Echo.<A>echo(n).apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/EchoM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/EchoM.java
@@ -1,0 +1,40 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.ReplicateM.replicateM;
+
+/**
+ * Repeat each element in an <code>IterateT</code> <code>n</code> times.
+ *
+ * @param <M> the IterateT effect type
+ * @param <A> The IterateT element type
+ */
+public class EchoM<M extends MonadRec<?, M>, A> implements Fn2<Integer, IterateT<M, A>, IterateT<M, A>> {
+
+    private static final EchoM<?, ?> INSTANCE = new EchoM<>();
+
+    private EchoM() {
+    }
+
+    @Override
+    public IterateT<M, A> checkedApply(Integer n, IterateT<M, A> mas) throws Throwable {
+        return mas.flatMap(a -> replicateM(n, mas.runIterateT().pure(a)));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> EchoM<M, A> echoM() {
+        return (EchoM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> Fn1<IterateT<M, A>, IterateT<M, A>> echoM(Integer n) {
+        return EchoM.<M, A>echoM().apply(n);
+    }
+
+    public static <M extends MonadRec<?, M>, A> IterateT<M,A> echoM(Integer n, IterateT<M,A> mas) {
+        return EchoM.<M,A>echoM(n).apply(mas);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/FilterM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/FilterM.java
@@ -1,0 +1,48 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn4.IfThenElse.ifThenElse;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.*;
+
+/**
+ * Lazily apply a predicate to each element in an <code>IterateT</code>, returning an <code>IterateT</code> of just the
+ * elements for which the predicate evaluated to <code>true</code>.
+ *
+ * @param <A> A type contravariant to the input IterateT element type
+ * @param <M> the IterateT effect type
+ * @see TakeWhileM
+ * @see DropWhileM
+ */
+public class FilterM<A, M extends MonadRec<?, M>> implements Fn2<Fn1<? super A, ? extends Boolean>, IterateT<M, A>, IterateT<M, A>> {
+
+    private static final FilterM<?, ?> INSTANCE = new FilterM<>();
+
+    @Override
+    public IterateT<M, A> checkedApply(Fn1<? super A, ? extends Boolean> predicate, IterateT<M, A> as) throws Throwable {
+        MonadRec<Maybe<Tuple2<A, IterateT<M, A>>>, M> unwrapped = as.runIterateT();
+        return iterateT(unwrapped)
+                .flatMap(ifThenElse(predicate,
+                                    a -> singleton(unwrapped.pure(a)),
+                                    __ -> empty(Pure.of(unwrapped))));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A, M extends MonadRec<?, M>> FilterM<A, M> filterM() {
+        return (FilterM<A, M>) INSTANCE;
+    }
+
+    public static <A, M extends MonadRec<?, M>> Fn1<IterateT<M, A>, IterateT<M, A>> filterM(Fn1<? super A, ? extends Boolean> predicate) {
+        return FilterM.<A, M>filterM().apply(predicate);
+    }
+
+    public static <A, M extends MonadRec<?, M>> IterateT<M, A> filterM(Fn1<? super A, ? extends Boolean> predicate, IterateT<M, A> as) {
+        return FilterM.<A, M>filterM(predicate).apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/FindM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/FindM.java
@@ -1,0 +1,45 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.HeadM.headM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.FilterM.filterM;
+
+/**
+ * Iterate the elements in an <code>IterateT</code>, applying a predicate to each one, returning the first element that
+ * matches the predicate, wrapped in a {@link Maybe}. If no elements match the predicate, the result is
+ * {@link Maybe#nothing()}. This function short-circuits, and so is safe to use on potentially infinite {@link Iterable}
+ * instances that guarantee to have an eventually matching element.
+ *
+ * @param <A> the IterateT element type
+ * @param <M> the IterateT effect type
+ */
+public class FindM<M extends MonadRec<?, M>, A, MMA extends MonadRec<Maybe<A>, M>> implements Fn2<Fn1<? super A, Boolean>, IterateT<M, A>, MMA> {
+
+    private static final FindM<?, ?, ?> INSTANCE = new FindM<>();
+
+    private FindM() {
+    }
+
+    @Override
+    public MMA checkedApply(Fn1<? super A, Boolean> predicate, IterateT<M, A> as) throws Throwable {
+        return headM(filterM(predicate, as));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A, MMA extends MonadRec<Maybe<A>, M>> FindM<M, A, MMA> findM() {
+        return (FindM<M, A, MMA>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A, MMA extends MonadRec<Maybe<A>, M>> Fn1<IterateT<M, A>, MMA> findM(Fn1<? super A, Boolean> predicate) {
+        return FindM.<M, A, MMA>findM().apply(predicate);
+    }
+
+    public static <M extends MonadRec<?, M>, A, MMA extends MonadRec<Maybe<A>, M>> MMA findM(Fn1<? super A, Boolean> predicate, IterateT<M, A> as) {
+        return FindM.<M, A, MMA>findM(predicate).apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/InGroupsOfM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/InGroupsOfM.java
@@ -1,0 +1,51 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.CycleM.cycleM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.EchoM.echoM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Eq.eq;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.MagnetizeByM.magnetizeByM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.ZipM.zipM;
+
+/**
+ * Lazily group the <code>IterateT</code> by returning an <code>IterateT</code> of smaller <code>IterateT</code>s of
+ * size <code>k</code>. Note that groups are <em>not</em> padded; that is, if <code>k &gt;= n</code>, where
+ * <code>n</code> is the number of remaining elements, the final <code>IterateT</code> will have only <code>n</code>
+ * elements.
+ *
+ * @param <A> The IterateT element type
+ * @param <M> The IterateT effect type
+ */
+public class InGroupsOfM<M extends MonadRec<?, M>, A> implements Fn2<Integer, IterateT<M, A>, IterateT<M, IterateT<M, A>>> {
+
+    private static final InGroupsOfM<?, ?> INSTANCE = new InGroupsOfM<>();
+
+    private InGroupsOfM() {
+    }
+
+    @Override
+    public IterateT<M, IterateT<M, A>> checkedApply(Integer k, IterateT<M, A> mas) throws Throwable {
+        MonadRec<Maybe<Tuple2<A, IterateT<M, A>>>, M> unwrapped = mas.runIterateT();
+        return magnetizeByM((t1, t2) -> eq(t1._1(), t2._1()), zipM(echoM(k, cycleM(IterateT.of(unwrapped.pure(true), unwrapped.pure(false)))), mas))
+                .fmap(it -> it.fmap(Tuple2::_2));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> InGroupsOfM<M, A> inGroupsOfM() {
+        return (InGroupsOfM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> Fn1<IterateT<M, A>, IterateT<M, IterateT<M, A>>> inGroupsOfM(Integer k) {
+        return InGroupsOfM.<M, A>inGroupsOfM().apply(k);
+    }
+
+    public static <M extends MonadRec<?, M>, A> IterateT<M, IterateT<M, A>> inGroupsOfM(Integer k, IterateT<M, A> mas) {
+        return InGroupsOfM.<M, A>inGroupsOfM(k).apply(mas);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/MagnetizeByM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/MagnetizeByM.java
@@ -1,0 +1,68 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.adt.hlist.Tuple3;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.recursion.RecursiveResult;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Into3.into3;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.recurse;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.terminate;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.suspended;
+
+/**
+ * Given a binary predicate and an <code>{@link IterateT}&lt;M, A&gt;</code>, return an <code>{@link IterateT}&lt;M, {@link
+ * IterateT}&lt;M, A&gt;&gt;</code> of the contiguous groups of elements that match the predicate pairwise.
+ * <p>
+ * See <code>{@link MagnetizeBy}</code> for an example using <code>Iterable</code>
+ *
+ * @param <A> the {@link IterateT} element type
+ * @param <M> the {@link IterateT} effect type
+ */
+public class MagnetizeByM<M extends MonadRec<?, M>, A> implements Fn2<Fn2<? super A, ? super A, Boolean>, IterateT<M, A>, IterateT<M, IterateT<M, A>>> {
+
+    private static final MagnetizeByM<?, ?> INSTANCE = new MagnetizeByM<>();
+
+    private MagnetizeByM() {
+    }
+
+    @Override
+    public IterateT<M, IterateT<M, A>> checkedApply(Fn2<? super A, ? super A, Boolean> predicate, IterateT<M, A> mas) {
+        MonadRec<Maybe<Tuple2<A, IterateT<M, A>>>, M> unwrappedA = mas.runIterateT();
+        return suspended(() -> unwrappedA
+                                 .fmap(m -> m.fmap(into((pivot, ys) -> tuple(pivot, mas.pure(pivot), ys))))
+                                 .trampolineM(m -> m.match(
+                                         __ -> unwrappedA.pure(terminate(nothing())),
+                                         into3((pivot, group, ys) -> ys.runIterateT().<RecursiveResult<Maybe<Tuple3<A, IterateT<M, A>, IterateT<M, A>>>, Maybe<Tuple2<IterateT<M, A>, IterateT<M, A>>>>>fmap(m2 -> m2.match(
+                                                 __ -> terminate(just(tuple(group, empty(Pure.of(unwrappedA))))),
+                                                 into((y, tail) ->
+                                                              predicate.apply(pivot, y)
+                                                              ? recurse(just(tuple(y, group.concat(mas.pure(y)), tail)))
+                                                              : terminate(just(tuple(group, mas.pure(y).concat(tail))))))))))
+                                 .fmap(m -> m.fmap(t -> t.fmap(magnetizeByM(predicate)))),
+                         Pure.of(unwrappedA));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> MagnetizeByM<M, A> magnetizeByM() {
+        return (MagnetizeByM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> Fn1<IterateT<M, A>, IterateT<M, IterateT<M, A>>> magnetizeByM(Fn2<? super A, ? super A, Boolean> predicate) {
+        return MagnetizeByM.<M, A>magnetizeByM().apply(predicate);
+    }
+
+    public static <M extends MonadRec<?, M>, A> IterateT<M, IterateT<M, A>> magnetizeByM(Fn2<? super A, ? super A, Boolean> predicate, IterateT<M, A> mas) {
+        return MagnetizeByM.<M, A>magnetizeByM(predicate).apply(mas);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/Nth.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/Nth.java
@@ -1,0 +1,42 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Head.head;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Drop.drop;
+
+/**
+ * Retrieve the element of an {@link Iterable}, found at ordinal index <code>k</code> wrapped in an {@link Maybe}. If
+ * the index <code>k</code> is less than or equal to the size of the {@link Iterable}, the result is
+ * {@link Maybe#nothing()}.
+ *
+ * @param <A> the Iterable element type
+ */
+public class Nth<A> implements Fn2<Integer, Iterable<A>, Maybe<A>> {
+
+    private static final Nth<?> INSTANCE = new Nth<>();
+
+    private Nth() {
+    }
+
+    @Override
+    public Maybe<A> checkedApply(Integer k, Iterable<A> as) throws Throwable {
+        return k <= 0 ? nothing() : head(drop(k - 1, as));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> Nth<A> nth() {
+        return (Nth<A>) INSTANCE;
+    }
+
+    public static <A> Fn1<Iterable<A>, Maybe<A>> nth(Integer k) {
+        return Nth.<A>nth().apply(k);
+    }
+
+    public static <A> Maybe<A> nth(Integer k, Iterable<A> as) {
+        return Nth.<A>nth(k).apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/NthM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/NthM.java
@@ -1,0 +1,47 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.HeadM.headM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.DropM.dropM;
+
+/**
+ * Retrieve the element of an {@link IterateT}, found at ordinal index <code>k</code> wrapped in an {@link Maybe} wrapped
+ * in the monadic effect. If the index <code>k</code> is less than or equal to the size of the {@link IterateT}, the
+ * result is {@link Maybe#nothing()} wrapped in the monadic effect.
+ *
+ * @param <A> the IterateT element type
+ * @param <M> the IterateT effect type
+ */
+public class NthM<M extends MonadRec<?, M>, A> implements Fn2<Integer, IterateT<M, A>, MonadRec<Maybe<A>, M>> {
+
+    private static final NthM<?, ?> INSTANCE = new NthM<>();
+
+    private NthM() {
+    }
+
+    @Override
+    public MonadRec<Maybe<A>, M> checkedApply(Integer k, IterateT<M, A> mas) throws Throwable {
+        MonadRec<Maybe<Tuple2<A, IterateT<M, A>>>, M> unwrapped = mas.runIterateT();
+        return k <= 0 ? unwrapped.pure(nothing()) : headM(dropM(k - 1, mas));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> NthM<M, A> nthM() {
+        return (NthM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> Fn1<IterateT<M, A>, MonadRec<Maybe<A>, M>> nthM(Integer k) {
+        return NthM.<M, A>nthM().apply(k);
+    }
+
+    public static <M extends MonadRec<?, M>, A> MonadRec<Maybe<A>, M> nthM(Integer k, IterateT<M, A> mas) {
+        return NthM.<M, A>nthM(k).apply(mas);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReplicateM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReplicateM.java
@@ -1,0 +1,43 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.RepeatM.repeatM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+
+/**
+ * Produce an {@link IterateT} of a value <code>n</code> times.
+ *
+ * @param <A> the output IterateT element type
+ * @param <M> the output IterateT element type
+ */
+
+public class ReplicateM<M extends MonadRec<?, M>, A> implements Fn2<Integer, MonadRec<A, M>, IterateT<M, A>> {
+
+    private static final ReplicateM<?, ?> INSTANCE = new ReplicateM<>();
+
+    private ReplicateM() {
+    }
+
+    @Override
+    public IterateT<M, A> checkedApply(Integer n, MonadRec<A, M> ma) throws Throwable {
+        if (n < 0) throw new IllegalArgumentException("Replica count must not be negative: " + n);
+        return takeM(n, repeatM(ma));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <M extends MonadRec<?, M>, A> ReplicateM<M, A> replicateM() {
+        return (ReplicateM<M, A>) INSTANCE;
+    }
+
+    public static <M extends MonadRec<?, M>, A> Fn1<MonadRec<A, M>, IterateT<M, A>> replicateM(Integer n) {
+        return ReplicateM.<M, A>replicateM().apply(n);
+    }
+
+    public static <M extends MonadRec<?, M>, A> IterateT<M, A> replicateM(Integer n, MonadRec<A, M> a) {
+        return ReplicateM.<M, A>replicateM(n).apply(a);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeM.java
@@ -1,0 +1,53 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.GT.gt;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.suspended;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+
+/**
+ * Lazily limit the <code>IterateT</code> to <code>n</code> elements by returning an <code>IterateT</code> that stops
+ * iteration after the <code>nth</code> element, or the last element of the <code>IterateT</code>, whichever comes
+ * first.
+ *
+ * @param <A> The IterateT element type
+ * @param <M> the IterateT effect type
+ * @see TakeWhileM
+ * @see DropM
+ */
+public class TakeM<A, M extends MonadRec<?, M>> implements Fn2<Integer, IterateT<M, A>, IterateT<M, A>> {
+
+    private static final TakeM<?, ?> INSTANCE = new TakeM<>();
+
+    @Override
+    public IterateT<M, A> checkedApply(Integer n, IterateT<M, A> as) throws Throwable {
+        MonadRec<Maybe<Tuple2<A, IterateT<M, A>>>, M> unwrapped = as.runIterateT();
+        return suspended(() -> gt(0, n)
+                               ? maybeT(unwrapped)
+                                       .fmap(t -> t.fmap(takeM(n - 1)))
+                                       .runMaybeT()
+                               : unwrapped.pure(nothing()),
+                         Pure.of(unwrapped));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A, M extends MonadRec<?, M>> TakeM<A, M> takeM() {
+        return (TakeM<A, M>) INSTANCE;
+    }
+
+    public static <A, M extends MonadRec<?, M>> Fn1<IterateT<M, A>, IterateT<M, A>> takeM(Integer n) {
+        return TakeM.<A, M>takeM().apply(n);
+    }
+
+    public static <A, M extends MonadRec<?, M>> IterateT<M, A> takeM(Integer n, IterateT<M, A> as) {
+        return TakeM.<A, M>takeM(n).apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeWhileM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeWhileM.java
@@ -1,0 +1,46 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.iterateT;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+
+/**
+ * Lazily limit the <code>IterateT</code> to the first group of contiguous elements that satisfy the predicate by
+ * iterating up to, but not including, the first element for which the predicate evaluates to <code>false</code>.
+ *
+ * @param <A> The IterateT element type
+ * @param <M> the IterateT effect type
+ * @see TakeM
+ * @see FilterM
+ * @see DropWhileM
+ */
+public class TakeWhileM<A, M extends MonadRec<?, M>> implements Fn2<Fn1<? super A, ? extends Boolean>, IterateT<M, A>, IterateT<M, A>> {
+
+    private static final TakeWhileM<?, ?> INSTANCE = new TakeWhileM<>();
+
+    @Override
+    public IterateT<M, A> checkedApply(Fn1<? super A, ? extends Boolean> predicate, IterateT<M, A> as) {
+        return iterateT(maybeT(as.runIterateT())
+                                .filter(predicate.diMapL(Tuple2::_1))
+                                .fmap(t -> t.fmap(takeWhileM(predicate)))
+                                .runMaybeT());
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A, M extends MonadRec<?, M>> TakeWhileM<A, M> takeWhileM() {
+        return (TakeWhileM<A, M>) INSTANCE;
+    }
+
+    public static <A, M extends MonadRec<?, M>> Fn1<IterateT<M, A>, IterateT<M, A>> takeWhileM(Fn1<? super A, ? extends Boolean> predicate) {
+        return TakeWhileM.<A, M>takeWhileM().apply(predicate);
+    }
+
+    public static <A, M extends MonadRec<?, M>> IterateT<M, A> takeWhileM(Fn1<? super A, ? extends Boolean> predicate, IterateT<M, A> as) {
+        return TakeWhileM.<A, M>takeWhileM(predicate).apply(as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/ZipM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/ZipM.java
@@ -1,0 +1,43 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Tupler2.tupler;
+import static com.jnape.palatable.lambda.functions.builtin.fn3.ZipWithM.zipWithM;
+
+/**
+ * Zip together two <code>IterateT</code>s into a single <code>IterateT</code> of <code>Tuple2&lt;A, B&gt;</code>. If
+ * the input <code>IterateT</code>s differ in size, the resulting <code>IterateT</code> contains only as many pairs as
+ * the smallest input <code>IterateT</code>'s elements.
+ *
+ * @param <A> The first input IterateT element type, and the type of the first tuple slot in the output IterateT
+ * @param <B> The second input IterateT element type, and the type of the second tuple slot in the output IterateT
+ * @param <M> the IterateT effect type
+ * @see com.jnape.palatable.lambda.functions.builtin.fn3.ZipWithM
+ */
+public class ZipM<A, B, M extends MonadRec<?, M>> implements Fn2<IterateT<M, A>, IterateT<M, B>, IterateT<M, Tuple2<A, B>>> {
+
+    private static final ZipM<?, ?, ?> INSTANCE = new ZipM<>();
+
+    @Override
+    public IterateT<M, Tuple2<A, B>> checkedApply(IterateT<M, A> as, IterateT<M, B> bs) throws Throwable {
+        return zipWithM(tupler(), as, bs);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A, B, M extends MonadRec<?, M>> ZipM<A, B, M> zipM() {
+        return (ZipM<A, B, M>) INSTANCE;
+    }
+
+    public static <A, B, M extends MonadRec<?, M>> Fn1<IterateT<M, B>, IterateT<M, Tuple2<A, B>>> zipM(IterateT<M, A> as) {
+        return ZipM.<A, B, M>zipM().apply(as);
+    }
+
+    public static <A, B, M extends MonadRec<?, M>> IterateT<M, Tuple2<A, B>> zipM(IterateT<M, A> as, IterateT<M, B> bs) {
+        return ZipM.<A, B, M>zipM(as).apply(bs);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/ZipWithM.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn3/ZipWithM.java
@@ -1,0 +1,61 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.HList;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.Fn3;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+
+import static com.jnape.palatable.lambda.functions.Fn1.fn1;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.suspended;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+
+/**
+ * Zip together two <code>IterateT</code>s by applying a zipping function to the successive elements of each
+ * <code>IterateT</code> until one of them runs out of elements. Returns an <code>IterateT</code> containing the
+ * results.
+ *
+ * @param <A> The first input IterateT element type
+ * @param <B> The second input IterateT element type
+ * @param <C> The output IterateT element type
+ * @param <M> the IterateT effect type
+ * @see com.jnape.palatable.lambda.functions.builtin.fn2.Zip
+ */
+public class ZipWithM<A, B, C, M extends MonadRec<?, M>> implements Fn3<Fn2<? super A, ? super B, ? extends C>, IterateT<M, A>, IterateT<M, B>, IterateT<M, C>> {
+
+    private static final ZipWithM<?, ?, ?, ?> INSTANCE = new ZipWithM<>();
+
+    @Override
+    @SuppressWarnings("RedundantTypeArguments")
+    public IterateT<M, C> checkedApply(Fn2<? super A, ? super B, ? extends C> zipFn, IterateT<M, A> as, IterateT<M, B> bs) {
+        MonadRec<Maybe<Tuple2<B, IterateT<M, B>>>, M> unwrappedB = bs.runIterateT();
+        return suspended(() -> maybeT(unwrappedB)
+                                 .zip(maybeT(as.runIterateT())
+                                              .fmap(ta -> fn1(tb -> HList.<C, IterateT<M, C>>tuple(
+                                                      zipFn.apply(ta._1(), tb._1()),
+                                                      ZipWithM.<A, B, C, M>zipWithM(zipFn, ta._2(), tb._2())))))
+                                 .runMaybeT(),
+                         Pure.of(unwrappedB));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A, B, C, M extends MonadRec<?, M>> ZipWithM<A, B, C, M> zipWithM() {
+        return (ZipWithM<A, B, C, M>) INSTANCE;
+    }
+
+    public static <A, B, C, M extends MonadRec<?, M>> Fn2<IterateT<M, A>, IterateT<M, B>, IterateT<M, C>> zipWithM(Fn2<? super A, ? super B, ? extends C> zipFn) {
+        return ZipWithM.<A, B, C, M>zipWithM().apply(zipFn);
+    }
+
+    public static <A, B, C, M extends MonadRec<?, M>> Fn1<IterateT<M, B>, IterateT<M, C>> zipWithM(Fn2<? super A, ? super B, ? extends C> zipFn, IterateT<M, A> as) {
+        return ZipWithM.<A, B, C, M>zipWithM(zipFn).apply(as);
+    }
+
+    public static <A, B, C, M extends MonadRec<?, M>> IterateT<M, C> zipWithM(Fn2<? super A, ? super B, ? extends C> zipFn, IterateT<M, A> as, IterateT<M, B> bs) {
+        return ZipWithM.<A, B, C, M>zipWithM(zipFn, as).apply(bs);
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn0/NaturalNumbersTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn0/NaturalNumbersTest.java
@@ -1,0 +1,34 @@
+package com.jnape.palatable.lambda.functions.builtin.fn0;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn0.NaturalNumbers.naturalNumbers;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Drop.drop;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+import static org.junit.Assert.*;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static testsupport.matchers.IterableMatcher.iterates;
+
+public class NaturalNumbersTest {
+    @Test
+    public void producesTheNats() {
+        Iterable<Integer> numbers = naturalNumbers();
+        assertThat(take(10, numbers), iterates(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    }
+
+    @Test
+    public void producesNatsForever() {
+        Iterable<Integer> numbers = naturalNumbers();
+        assertThat(take(10, drop(STACK_EXPLODING_NUMBER, numbers)),
+                   iterates(STACK_EXPLODING_NUMBER + 1,
+                            STACK_EXPLODING_NUMBER + 2,
+                            STACK_EXPLODING_NUMBER + 3,
+                            STACK_EXPLODING_NUMBER + 4,
+                            STACK_EXPLODING_NUMBER + 5,
+                            STACK_EXPLODING_NUMBER + 6,
+                            STACK_EXPLODING_NUMBER + 7,
+                            STACK_EXPLODING_NUMBER + 8,
+                            STACK_EXPLODING_NUMBER + 9,
+                            STACK_EXPLODING_NUMBER + 10));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CatMaybesMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CatMaybesMTest.java
@@ -1,0 +1,38 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.CatMaybesM.catMaybesM;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.RepeatM.repeatM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.MaybeT.maybeT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IterateTMatcher.isEmpty;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class CatMaybesMTest {
+
+    @Test
+    public void emptyStaysEmpty() {
+        assertThat(catMaybesM(empty(pureIdentity())), isEmpty());
+    }
+
+    @Test
+    public void nothingButNothing() {
+        assertThat(catMaybesM(takeM(4, repeatM(new Identity<>(nothing())))), isEmpty());
+    }
+
+    @Test
+    public void justAFew() {
+        IterateT<Identity<?>, Maybe<Integer>> numbers =
+                maybeT(naturalNumbersM(pureIdentity()).fmap(Maybe::just)).filter(x -> x % 2 == 0).runMaybeT();
+        assertThat(takeM(3, catMaybesM(numbers)), iterates(2, 4, 6));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CycleMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/CycleMTest.java
@@ -1,0 +1,66 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+import testsupport.matchers.IterableMatcher;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.CycleM.cycleM;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.DropM.dropM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.NthM.nthM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.fromIterator;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class CycleMTest {
+    @Test
+    public void cyclesTheSameSequence() {
+        assertThat(takeM(9, cycleM(takeM(3, naturalNumbersM(pureIdentity())))),
+                   iterates(1, 2, 3, 1, 2, 3, 1, 2, 3));
+    }
+
+    @Test
+    public void cyclesTheSameSequenceForever() {
+        assertThat(takeM(9, dropM(STACK_EXPLODING_NUMBER - STACK_EXPLODING_NUMBER % 3, cycleM(takeM(3, naturalNumbersM(pureIdentity()))))),
+                   iterates(1, 2, 3, 1, 2, 3, 1, 2, 3));
+    }
+
+    @Test
+    public void infinityInfinities() {
+        Identity<Maybe<Integer>> actual = nthM(STACK_EXPLODING_NUMBER, cycleM(naturalNumbersM(pureIdentity()))).coerce();
+        assertThat(actual.runIdentity(), equalTo(just(STACK_EXPLODING_NUMBER)));
+    }
+
+    @Test
+    public void cyclesArePredictablyWeirdWithNonRepeatableSequences() {
+        AtomicInteger theCount = new AtomicInteger(0);
+        IterateT<IO<?>, Integer> numbers = fromIterator(new Iterator<Integer>() {
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return theCount.incrementAndGet();
+            }
+        });
+        IterateT<IO<?>, Integer> x = takeM(10, cycleM(takeM(2, numbers)));
+        IO<List<Integer>> y = x.toCollection(ArrayList::new);
+        List<Integer> actual = y.unsafePerformIO();
+        assertThat(actual, IterableMatcher.iterates(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/HeadMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/HeadMTest.java
@@ -1,0 +1,28 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.HeadM.headM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static org.junit.Assert.assertEquals;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+
+public class HeadMTest {
+
+    @Test
+    public void headEmpty() {
+        Identity<Maybe<Integer>> mma = headM(empty(pureIdentity()));
+        assertEquals(mma.runIdentity(), nothing());
+    }
+
+    @Test
+    public void headInfinite() {
+        Identity<Maybe<Integer>> mma = headM(naturalNumbersM(pureIdentity()));
+        assertEquals(mma.runIdentity(), just(1));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/IndexMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/IndexMTest.java
@@ -1,0 +1,24 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.IndexM.indexM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.ReplicateM.replicateM;
+import static org.junit.Assert.*;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class IndexMTest {
+
+    @Test
+    public void indexes() {
+        IterateT<Identity<?>, Character> as = replicateM(5, new Identity<>('a'));
+        assertThat(indexM(as), iterates(tuple(1, 'a'),
+                                        tuple(2, 'a'),
+                                        tuple(3, 'a'),
+                                        tuple(4, 'a'),
+                                        tuple(5, 'a')));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/IndexTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/IndexTest.java
@@ -1,0 +1,18 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Index.index;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Replicate.replicate;
+import static org.junit.Assert.*;
+import static testsupport.matchers.IterableMatcher.iterates;
+
+public class IndexTest {
+
+    @Test
+    public void indexes() {
+        Iterable<Character> as = replicate(5, 'a');
+        assertThat(index(as), iterates(tuple(1, 'a'), tuple(2, 'a'), tuple(3, 'a'), tuple(4, 'a'), tuple(5, 'a')));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/MagnetizeMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/MagnetizeMTest.java
@@ -1,0 +1,33 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.MagnetizeM.magnetizeM;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.RepeatM.repeatM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.*;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class MagnetizeMTest {
+
+    @Test
+    public void groupsLikeElements() {
+        IterateT<Identity<?>, Integer> numbers = takeM(10, naturalNumbersM(pureIdentity()).flatMap(n -> takeM(n, repeatM(new Identity<>(n)))));
+        List<IterateT<Identity<?>, Integer>> actual = magnetizeM(numbers)
+                .<List<IterateT<Identity<?>, Integer>>, Identity<List<IterateT<Identity<?>, Integer>>>>toCollection(ArrayList::new)
+                .runIdentity();
+
+        assertThat(actual, contains(iterates(1),
+                                    iterates(2, 2),
+                                    iterates(3, 3, 3),
+                                    iterates(4, 4, 4, 4)));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/NaturalNumbersMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/NaturalNumbersMTest.java
@@ -1,0 +1,68 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.recursion.RecursiveResult;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.LT.lt;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.LTE.lte;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Snoc.snoc;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Tupler2.tupler;
+import static com.jnape.palatable.lambda.functions.builtin.fn4.IfThenElse.ifThenElse;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.recurse;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.terminate;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.*;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static testsupport.matchers.IterableMatcher.iterates;
+
+public class NaturalNumbersMTest {
+    @Test
+    public void producesTheNats() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        Iterable<Integer> sample = numbers
+                .<Iterable<Integer>, Identity<Iterable<Integer>>>foldCut(
+                        (acc, n) -> new Identity<>(lte(10, n)
+                                                   ? recurse(snoc(n, acc))
+                                                   : terminate(acc)),
+                        new Identity<>(emptyList()))
+                .runIdentity();
+        assertThat(sample, iterates(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    }
+
+    @Test
+    public void producesNatsForever() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        Iterable<Integer> sample = numbers
+                .<Iterable<Integer>, Identity<Iterable<Integer>>>foldCut(
+                        (acc, n) -> new Identity<>(lt(STACK_EXPLODING_NUMBER, n)
+                                                   ? recurse(acc)
+                                                   : lte(STACK_EXPLODING_NUMBER + 10, n)
+                                                     ? recurse(snoc(n, acc))
+                                                     : terminate(acc)),
+                        new Identity<>(emptyList()))
+                .runIdentity();
+        assertThat(sample, iterates(STACK_EXPLODING_NUMBER,
+                                    STACK_EXPLODING_NUMBER + 1,
+                                    STACK_EXPLODING_NUMBER + 2,
+                                    STACK_EXPLODING_NUMBER + 3,
+                                    STACK_EXPLODING_NUMBER + 4,
+                                    STACK_EXPLODING_NUMBER + 5,
+                                    STACK_EXPLODING_NUMBER + 6,
+                                    STACK_EXPLODING_NUMBER + 7,
+                                    STACK_EXPLODING_NUMBER + 8,
+                                    STACK_EXPLODING_NUMBER + 9,
+                                    STACK_EXPLODING_NUMBER + 10));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/RepeatMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/RepeatMTest.java
@@ -1,0 +1,28 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.RepeatM.repeatM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.NthM.nthM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class RepeatMTest {
+
+    @Test
+    public void repeatsAThing() {
+        assertThat(takeM(10, repeatM(new Identity<>(1))), iterates(1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
+    }
+
+    @Test
+    public void repeatsALotOfThings() {
+        Identity<Maybe<Integer>> actual = nthM(STACK_EXPLODING_NUMBER, repeatM(new Identity<>(1))).coerce();
+        assertThat(actual.runIdentity(), equalTo(just(1)));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropMTest.java
@@ -1,0 +1,51 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.HeadM.headM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.DropM.dropM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static org.junit.Assert.*;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IterateTMatcher.*;
+
+public class DropMTest {
+
+    @Test
+    public void dropEmpty() {
+        IterateT<Identity<?>, Integer> numbers = empty(pureIdentity());
+        assertThat(dropM(5, numbers), isEmpty());
+    }
+
+    @Test
+    public void dropAllShort() {
+        IterateT<Identity<?>, Integer> numbers = takeM(3, naturalNumbersM(pureIdentity()));
+        assertThat(dropM(5, numbers), isEmpty());
+    }
+
+    @Test
+    public void dropAll() {
+        IterateT<Identity<?>, Integer> numbers = takeM(5, naturalNumbersM(pureIdentity()));
+        assertThat(dropM(5, numbers), isEmpty());
+    }
+
+    @Test
+    public void dropSome() {
+        IterateT<Identity<?>, Integer> numbers = takeM(6, naturalNumbersM(pureIdentity()));
+        assertThat(dropM(5, numbers), iterates(6));
+    }
+
+    @Test
+    public void dropStackSafe() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        Identity<Maybe<Integer>> actual = headM(dropM(STACK_EXPLODING_NUMBER, numbers));
+        assertEquals(just(STACK_EXPLODING_NUMBER + 1), actual.runIdentity());
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileMTest.java
@@ -1,0 +1,58 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.HeadM.headM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.DropWhileM.dropWhileM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.LT.lt;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.LTE.lte;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IterateTMatcher.isEmpty;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class DropWhileMTest {
+
+    private static final Fn1<Integer, Integer> MOD_7 = i -> i % 7;
+
+    @Test
+    public void dropEmpty() {
+        IterateT<Identity<?>, Integer> numbers = empty(pureIdentity());
+        assertThat(dropWhileM(constantly(true), numbers), isEmpty());
+    }
+
+    @Test
+    public void dropAll() {
+        IterateT<Identity<?>, Integer> numbers = takeM(10, naturalNumbersM(pureIdentity()));
+        assertThat(dropWhileM(lt(100), numbers), isEmpty());
+    }
+
+    @Test
+    public void dropSome() {
+        IterateT<Identity<?>, Integer> numbers = takeM(10, naturalNumbersM(pureIdentity()));
+        assertThat(dropWhileM(lte(5), numbers), iterates(6, 7, 8, 9, 10));
+    }
+
+    @Test
+    public void dropSomeIntermittent() {
+        IterateT<Identity<?>, Integer> numbers = takeM(10, naturalNumbersM(pureIdentity()));
+        assertThat(dropWhileM(lte(5).diMapL(MOD_7), numbers), iterates(6, 7, 8, 9, 10));
+    }
+    @Test
+    public void dropStackSafe() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        Identity<Maybe<Integer>> actual = headM(dropWhileM(lte(STACK_EXPLODING_NUMBER), numbers));
+        assertEquals(just(STACK_EXPLODING_NUMBER + 1), actual.runIdentity());
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/EchoMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/EchoMTest.java
@@ -1,0 +1,30 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.EchoM.echoM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.DropM.dropM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class EchoMTest {
+
+    @Test
+    public void echoesEachElement() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        assertThat(takeM(9, echoM(3, numbers)), iterates(1, 1, 1, 2, 2, 2, 3, 3, 3));
+    }
+
+    @Test
+    public void echoesEachElementForever() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        assertThat(takeM(3, dropM(3 * (STACK_EXPLODING_NUMBER - 1), echoM(3, numbers))),
+                   iterates(STACK_EXPLODING_NUMBER, STACK_EXPLODING_NUMBER, STACK_EXPLODING_NUMBER));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/EchoTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/EchoTest.java
@@ -1,0 +1,27 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Drop.drop;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Echo.echo;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Iterate.iterate;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static testsupport.matchers.IterableMatcher.iterates;
+
+public class EchoTest {
+
+    @Test
+    public void echoesEachElement() {
+        Iterable<Integer> numbers = iterate(x -> x + 1, 1);
+        assertThat(take(9, echo(3, numbers)), iterates(1, 1, 1, 2, 2, 2, 3, 3, 3));
+    }
+
+    @Test
+    public void echoesEachElementForever() {
+        Iterable<Integer> numbers = iterate(x -> x + 1, 1);
+        assertThat(take(3, drop(3 * (STACK_EXPLODING_NUMBER - 1), echo(3, numbers))),
+                   iterates(STACK_EXPLODING_NUMBER, STACK_EXPLODING_NUMBER, STACK_EXPLODING_NUMBER));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/FilterMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/FilterMTest.java
@@ -1,0 +1,66 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.FilterM.filterM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.GT.gt;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.LT.lt;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static com.jnape.palatable.lambda.io.IO.pureIO;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static com.jnape.palatable.lambda.semigroup.builtin.Max.max;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+import static testsupport.matchers.IterateTMatcher.isEmpty;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class FilterMTest {
+
+    @Test
+    public void filterEmpty() {
+        IterateT<Identity<?>, Integer> numbers = empty(pureIdentity());
+        assertThat(filterM(constantly(true), numbers), isEmpty());
+    }
+
+    @Test
+    public void filterNothing() {
+        IterateT<Identity<?>, Integer> numbers = takeM(5, naturalNumbersM(pureIdentity()));
+        assertThat(filterM(constantly(true), numbers), iterates(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void filterAll() {
+        IterateT<Identity<?>, Integer> numbers = takeM(5, naturalNumbersM(pureIdentity()));
+        assertThat(filterM(constantly(false), numbers), isEmpty());
+    }
+
+    @Test
+    public void filterSome() {
+        IterateT<Identity<?>, Integer> numbers = takeM(5, naturalNumbersM(pureIdentity()));
+        assertThat(filterM(gt(3), numbers), iterates(4, 5));
+        assertThat(filterM(lt(3), numbers), iterates(1, 2));
+    }
+
+    @Test
+    public void filterSomeIntermittent() {
+        IterateT<Identity<?>, Integer> numbers = takeM(10, naturalNumbersM(pureIdentity()));
+        assertThat(filterM(i -> i % 2 == 0, numbers), iterates(2, 4, 6, 8, 10));
+        assertThat(filterM(i -> i % 2 == 1, numbers), iterates(1, 3, 5, 7, 9));
+    }
+
+    @Test
+    public void filterStackSafe() {
+        IterateT<IO<?>, Integer> numbers = takeM(STACK_EXPLODING_NUMBER, naturalNumbersM(pureIO()));
+        assertThat(filterM(constantly(true), numbers).fold((a, i) -> io(max(a, i)), io(0)),
+                   yieldsValue(equalTo(STACK_EXPLODING_NUMBER)));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/FindMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/FindMTest.java
@@ -1,0 +1,47 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.io.IO;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.FindM.findM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.GTE.gte;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.io.IO.pureIO;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+
+public class FindMTest {
+    @Test
+    public void findsSomething() {
+        Identity<Maybe<Integer>> actual = findM(gte(4), takeM(10, naturalNumbersM(pureIdentity())));
+        assertThat(actual.runIdentity(), equalTo(just(4)));
+    }
+
+    @Test
+    public void findsNothingWhenEmpty() {
+        Identity<Maybe<Integer>> actual = findM(constantly(true), empty(pureIdentity()));
+        assertThat(actual.runIdentity(), equalTo(nothing()));
+    }
+
+    @Test
+    public void findsNothingWhenNothingMatches() {
+        Identity<Maybe<Integer>> actual = findM(gte(14), takeM(10, naturalNumbersM(pureIdentity())));
+        assertThat(actual.runIdentity(), equalTo(nothing()));
+    }
+
+    @Test
+    public void findsANeedleInAHaystack() {
+        IO<Maybe<Integer>> actual = findM(gte(STACK_EXPLODING_NUMBER), naturalNumbersM(pureIO()));
+        assertThat(actual, yieldsValue(equalTo(just(STACK_EXPLODING_NUMBER))));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/InGroupsOfMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/InGroupsOfMTest.java
@@ -1,0 +1,39 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.InGroupsOfM.inGroupsOfM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.assertThat;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class InGroupsOfMTest {
+
+    @Test
+    public void evenlyDividedGroupsOfTwo() {
+        IterateT<Identity<?>, Integer> numbers = takeM(6, naturalNumbersM(pureIdentity()));
+        List<IterateT<Identity<?>, Integer>> actual =
+                inGroupsOfM(2, numbers)
+                        .<List<IterateT<Identity<?>, Integer>>, Identity<List<IterateT<Identity<?>, Integer>>>>toCollection(ArrayList::new)
+                        .runIdentity();
+        assertThat(actual, contains(iterates(1, 2), iterates(3, 4), iterates(5, 6)));
+    }
+
+    @Test
+    public void groupsOfTwoWithLastGroupShort() {
+        IterateT<Identity<?>, Integer> numbers = takeM(5, naturalNumbersM(pureIdentity()));
+        List<IterateT<Identity<?>, Integer>> actual =
+                inGroupsOfM(2, numbers)
+                        .<List<IterateT<Identity<?>, Integer>>, Identity<List<IterateT<Identity<?>, Integer>>>>toCollection(ArrayList::new)
+                        .runIdentity();
+        assertThat(actual, contains(iterates(1, 2), iterates(3, 4), iterates(5)));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/MagnetizeByMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/MagnetizeByMTest.java
@@ -1,0 +1,86 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.MonadRec;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+import testsupport.matchers.IterableMatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.CycleM.cycleM;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Drop.drop;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.GTE.gte;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.LT.lt;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.MagnetizeByM.magnetizeByM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Map.map;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.NthM.nthM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functions.builtin.fn3.FoldLeft.foldLeft;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.singleton;
+import static java.util.Arrays.asList;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static testsupport.matchers.IterateTMatcher.isEmpty;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class MagnetizeByMTest {
+    @Test
+    public void magnetizesEmpty() {
+        assertThat(magnetizeByM(GTE.<Integer>gte(), empty(pureIdentity())), isEmpty());
+    }
+
+    @Test
+    public void magnetizesSingleton() {
+        List<IterateT<Identity<?>, Integer>> actual = magnetizeByM(gte(), singleton(new Identity<>(1)))
+                .<List<IterateT<Identity<?>, Integer>>, Identity<List<IterateT<Identity<?>, Integer>>>>toCollection(ArrayList::new)
+                .runIdentity();
+        assertThat(actual, contains(iterates(1)));
+    }
+
+    @Test
+    public void magnetizesElementsInSeveralGroups() {
+        List<IterateT<Identity<?>, Integer>> actual = magnetizeByM(gte(), fromIterable(pureIdentity(), asList(1, 2, 3, 2, 2, 3, 2, 1)))
+                .<List<IterateT<Identity<?>, Integer>>, Identity<List<IterateT<Identity<?>, Integer>>>>toCollection(ArrayList::new)
+                .runIdentity();
+        assertThat(actual, contains(iterates(1, 2, 3),
+                                    iterates(2, 2, 3),
+                                    iterates(2),
+                                    iterates(1)));
+    }
+
+    @Test
+    public void magnetizesLargeGroups() {
+        IterateT<Identity<?>, Integer> numbers = cycleM(takeM(10_000, naturalNumbersM(pureIdentity())));
+        Identity<Maybe<IterateT<Identity<?>, Integer>>> maybeIdentity = nthM(3, magnetizeByM(gte(), numbers)).coerce();
+        List<Integer> thirdGroup = maybeIdentity
+                .runIdentity()
+                .orElseThrow(AssertionError::new)
+                .<List<Integer>, Identity<List<Integer>>>toCollection(ArrayList::new)
+                .runIdentity();
+        assertThat(thirdGroup, hasSize(10_000));
+        assertThat(take(3, thirdGroup), IterableMatcher.iterates(1, 2, 3));
+        assertThat(drop(9_997, thirdGroup), IterableMatcher.iterates(9_998, 9_999, 10_000));
+    }
+
+    @Test
+    public void magnetizesLotsOfSmallGroups() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        Identity<Maybe<IterateT<Identity<?>, Integer>>> group = nthM(STACK_EXPLODING_NUMBER, magnetizeByM(lt(), numbers)).coerce();
+        IterateT<Identity<?>, Integer> actual = group.runIdentity().orElseThrow(AssertionError::new);
+        assertThat(actual, iterates(STACK_EXPLODING_NUMBER));
+    }
+
+    private static <M extends MonadRec<?, M>, A> IterateT<M, A> fromIterable(Pure<M> pureM, Iterable<A> as) {
+        return foldLeft(IterateT::snoc, empty(pureM), map(pureM::<A, MonadRec<A, M>>apply, as));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/NthMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/NthMTest.java
@@ -1,0 +1,56 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.NthM.nthM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+
+public class NthMTest {
+
+    @Test
+    public void negativeNthIsNothing() {
+        Identity<Maybe<Integer>> actual = nthM(-5, naturalNumbersM(pureIdentity())).coerce();
+        assertThat(actual.runIdentity(), equalTo(nothing()));
+    }
+
+    @Test
+    public void zerothIsNothing() {
+        Identity<Maybe<Integer>> actual = nthM(0, naturalNumbersM(pureIdentity())).coerce();
+        assertThat(actual.runIdentity(), equalTo(nothing()));
+    }
+
+    @Test
+    public void nthFromEmpty() {
+        Identity<Maybe<Integer>> actual = nthM(5, IterateT.<Identity<?>, Integer>empty(pureIdentity())).coerce();
+        assertThat(actual.runIdentity(), equalTo(nothing()));
+    }
+
+    @Test
+    public void nthAfterEnd() {
+        Identity<Maybe<Integer>> actual = nthM(5, takeM(3, naturalNumbersM(pureIdentity()))).coerce();
+        assertThat(actual.runIdentity(), equalTo(nothing()));
+    }
+
+    @Test
+    public void nthWithinRange() {
+        Identity<Maybe<Integer>> actual = nthM(5, takeM(10, naturalNumbersM(pureIdentity()))).coerce();
+        assertThat(actual.runIdentity(), equalTo(just(5)));
+    }
+
+    @Test
+    public void largeNthFromInfinite() {
+        Identity<Maybe<Integer>> actual = nthM(STACK_EXPLODING_NUMBER, naturalNumbersM(pureIdentity())).coerce();
+        assertThat(actual.runIdentity(), equalTo(just(STACK_EXPLODING_NUMBER)));
+    }
+
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/NthTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/NthTest.java
@@ -1,0 +1,45 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn0.NaturalNumbers.naturalNumbers;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Nth.nth;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+
+public class NthTest {
+    @Test
+    public void negativeNthIsNothing() {
+        assertThat(nth(-5, naturalNumbers()), equalTo(nothing()));
+    }
+
+    @Test
+    public void zerothIsNothing() {
+        assertThat(nth(0, naturalNumbers()), equalTo(nothing()));
+    }
+
+    @Test
+    public void nthFromEmpty() {
+        assertThat(nth(5, emptyList()), equalTo(nothing()));
+    }
+
+    @Test
+    public void nthAfterEnd() {
+        assertThat(nth(5, take(3, naturalNumbers())), equalTo(nothing()));
+    }
+
+    @Test
+    public void nthWithinRange() {
+        assertThat(nth(5, take(10, naturalNumbers())), equalTo(just(5)));
+    }
+
+    @Test
+    public void largeNthFromInfinite() {
+        assertThat(nth(STACK_EXPLODING_NUMBER, naturalNumbers()), equalTo(just(STACK_EXPLODING_NUMBER)));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReplicateMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ReplicateMTest.java
@@ -1,0 +1,22 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.ReplicateM.replicateM;
+import static org.junit.Assert.assertThat;
+import static testsupport.matchers.IterateTMatcher.isEmpty;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class ReplicateMTest {
+
+    @Test
+    public void emptyWithZeroReplicas() {
+        assertThat(replicateM(0, new Identity<>(1)), isEmpty());
+    }
+
+    @Test
+    public void populatedWithMoreThanZeroReplicas() {
+        assertThat(replicateM(3, new Identity<>('1')), iterates('1', '1', '1'));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeMTest.java
@@ -1,0 +1,63 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static com.jnape.palatable.lambda.io.IO.pureIO;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.of;
+import static java.util.Arrays.asList;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+import static testsupport.matchers.IterateTMatcher.isEmpty;
+import static testsupport.matchers.IterateTMatcher.iteratesAll;
+
+public class TakeMTest {
+
+    @Test
+    public void takeEmpty() {
+        IterateT<Identity<?>, Integer> numbers = empty(pureIdentity());
+        assertThat(takeM(5, numbers), isEmpty());
+    }
+
+    @Test
+    public void takeAllShort() {
+        IterateT<Identity<?>, Integer> numbers = of(new Identity<>(1), new Identity<>(2), new Identity<>(3));
+        assertThat(takeM(5, numbers), iteratesAll(asList(1, 2, 3)));
+    }
+
+    @Test
+    public void takeAll() {
+        IterateT<Identity<?>, Integer> numbers = of(new Identity<>(1), new Identity<>(2), new Identity<>(3),
+                                                    new Identity<>(4), new Identity<>(5));
+        assertThat(takeM(5, numbers), iteratesAll(asList(1, 2, 3, 4, 5)));
+    }
+
+    @Test
+    public void takeSome() {
+        IterateT<Identity<?>, Integer> numbers = of(new Identity<>(1), new Identity<>(2), new Identity<>(3),
+                                                    new Identity<>(4), new Identity<>(5), new Identity<>(6));
+        assertThat(takeM(5, numbers), iteratesAll(asList(1, 2, 3, 4, 5)));
+    }
+
+    @Test
+    public void takeSomeInfinite() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        assertThat(takeM(5, numbers), iteratesAll(asList(1, 2, 3, 4, 5)));
+    }
+
+    @Test
+    public void takeStackSafe() {
+        IterateT<IO<?>, Integer> numbers = naturalNumbersM(pureIO());
+        assertThat(takeM(STACK_EXPLODING_NUMBER, numbers).fold((a, i) -> io(a + i), io(0)),
+                   yieldsValue(equalTo((STACK_EXPLODING_NUMBER + 1) * (STACK_EXPLODING_NUMBER / 2))));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeWhileMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/TakeWhileMTest.java
@@ -1,0 +1,66 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.io.IO;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.GT.gt;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.LT.lt;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.LTE.lte;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeWhileM.takeWhileM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.io.IO.io;
+import static com.jnape.palatable.lambda.io.IO.pureIO;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static com.jnape.palatable.lambda.semigroup.builtin.Max.max;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IOMatcher.yieldsValue;
+import static testsupport.matchers.IterateTMatcher.isEmpty;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class TakeWhileMTest {
+
+    public static final Fn1<Integer, Integer> MOD_10 = i -> i % 10;
+
+    @Test
+    public void takeEmpty() {
+        IterateT<Identity<?>, Integer> numbers = empty(pureIdentity());
+        assertThat(takeWhileM(lt(5), numbers), isEmpty());
+    }
+
+    @Test
+    public void takeNothing() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        assertThat(takeWhileM(gt(5), numbers), isEmpty());
+    }
+
+    @Test
+    public void takeSomeInfinite() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        assertThat(takeWhileM(lte(5), numbers), iterates(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void takeNothingIntermittent() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        assertThat(takeWhileM(gt(5).diMapL(MOD_10), numbers), isEmpty());
+    }
+
+    @Test
+    public void takeSomeIntermittent() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        assertThat(takeWhileM(lte(5).diMapL(MOD_10), numbers), iterates(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void takeStackSafe() {
+        IterateT<IO<?>, Integer> numbers = naturalNumbersM(pureIO());
+        assertThat(takeWhileM(lte(STACK_EXPLODING_NUMBER), numbers).fold((a, i) -> io(max(a, i)), io(0)),
+                   yieldsValue(equalTo(STACK_EXPLODING_NUMBER)));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ZipMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/ZipMTest.java
@@ -1,0 +1,40 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.ZipM.zipM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static com.jnape.palatable.lambda.monad.transformer.builtin.IterateT.empty;
+import static org.junit.Assert.*;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IterateTMatcher.isEmpty;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class ZipMTest {
+    @Test
+    public void zipEmpty() {
+        IterateT<Identity<?>, Integer> numbers = empty(pureIdentity());
+        IterateT<Identity<?>, String> strings = empty(pureIdentity());
+        assertThat(zipM(numbers, strings), isEmpty());
+    }
+
+    @Test
+    public void zipSameSize() {
+        IterateT<Identity<?>, Integer> numbers = takeM(5, naturalNumbersM(pureIdentity()));
+        IterateT<Identity<?>, String> strings = numbers.fmap(Integer::toBinaryString);
+        assertThat(zipM(numbers, strings), iterates(tuple(1, "1"), tuple(2, "10"), tuple(3, "11"),
+                                                    tuple(4, "100"), tuple(5, "101")));
+    }
+
+    @Test
+    public void zipDifferentSize() {
+        IterateT<Identity<?>, Integer> numbers = naturalNumbersM(pureIdentity());
+        IterateT<Identity<?>, String> strings = takeM(5, numbers).fmap(Integer::toBinaryString);
+        assertThat(zipM(numbers, strings), iterates(tuple(1, "1"), tuple(2, "10"), tuple(3, "11"),
+                                                    tuple(4, "100"), tuple(5, "101")));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/ZipWithMTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/ZipWithMTest.java
@@ -1,0 +1,28 @@
+package com.jnape.palatable.lambda.functions.builtin.fn3;
+
+import com.jnape.palatable.lambda.functor.builtin.Identity;
+import com.jnape.palatable.lambda.monad.transformer.builtin.IterateT;
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.DropM.dropM;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.TakeM.takeM;
+import static com.jnape.palatable.lambda.functions.builtin.fn3.ZipWithM.zipWithM;
+import static com.jnape.palatable.lambda.functor.builtin.Identity.pureIdentity;
+import static org.junit.Assert.*;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.NaturalNumbersM.naturalNumbersM;
+import static testsupport.matchers.IterateTMatcher.iterates;
+
+public class ZipWithMTest {
+
+    @Test
+    public void zipsSquares() {
+        IterateT<Identity<?>, Integer> numbers = takeM(5, naturalNumbersM(pureIdentity()));
+        assertThat(zipWithM((a, b) -> a * b, numbers, numbers.fmap(i -> i + 10)), iterates(11, 24, 39, 56, 75));
+    }
+
+    @Test
+    public void zipsAsymetrical() {
+        IterateT<Identity<?>, Integer> numbers = takeM(15, naturalNumbersM(pureIdentity()));
+        assertThat(zipWithM((a, b) -> a * b, numbers, dropM(10, numbers)), iterates(11, 24, 39, 56, 75));
+    }
+}


### PR DESCRIPTION
Implementations of the following functions for operating on IterateT which have an existing analog for operating on Iterable:

- FilterM
- HeadM
- FindM
- CatMaybesM
- DropM
- DropWhileM
- TakeM
- TakeWhileM
- ZipWithM
- ZipM
- RepeatM
- ReplicateM
- CycleM
- MagnetizeM
- MagnetizeByM
- InGroupsOfM

Additionally, there are implementations of the following new functions for operating on Iterable and IterateT respectively:

- NaturalNumbers and NaturalNumbersM: emit the sequence of natural numbers
- Index and IndexM: pair each element with its ordinal index
- Nth and NthM: retrieve the element found at ordinal index k in the input
- Echo and EchoM: repeat each element of the input n times

The are no cyclic dependencies in the implementations of these functional or in their tests. I have verified that each commit in the history builds and tests successfully.