### PR TITLE
Additional builtin functions for operating on Iterable

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn0/NaturalNumbers.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn0/NaturalNumbers.java
@@ -1,0 +1,22 @@
+package com.jnape.palatable.lambda.functions.builtin.fn0;
+
+import com.jnape.palatable.lambda.functions.Fn0;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Iterate.iterate;
+
+public class NaturalNumbers implements Fn0<Iterable<Integer>> {
+
+    private static final NaturalNumbers INSTANCE = new NaturalNumbers();
+
+    private NaturalNumbers() {
+    }
+
+    @Override
+    public Iterable<Integer> checkedApply() {
+        return iterate(x -> x + 1, 1);
+    }
+
+    public static Iterable<Integer> naturalNumbers() {
+        return INSTANCE.apply();
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/Index.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn1/Index.java
@@ -1,0 +1,35 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.builtin.fn2.Zip;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn0.NaturalNumbers.naturalNumbers;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.$.$;
+
+/**
+ * Given an <code>{@link Iterable}&lt;A&gt;</code>, pair each element with its ordinal index.
+ *
+ * @param <A> the Iterable element type
+ */
+public class Index<A> implements Fn1<Iterable<A>, Iterable<Tuple2<Integer, A>>> {
+
+    private static final Index<?> INSTANCE = new Index<>();
+
+    private Index() {
+    }
+
+    @Override
+    public Iterable<Tuple2<Integer, A>> checkedApply(Iterable<A> as) throws Throwable {
+        return Zip.zip(naturalNumbers(), as);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> Index<A> index() {
+        return (Index<A>) INSTANCE;
+    }
+
+    public static <A> Iterable<Tuple2<Integer, A>> index(Iterable<A> as) {
+        return $(index(), as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/Echo.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/Echo.java
@@ -1,0 +1,40 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Flatten.flatten;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.$.$;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Map.map;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Replicate.replicate;
+
+/**
+ * Repeat each element in an <code>Iterable</code> <code>n</code> times.
+ *
+ * @param <A> The Iterable element type
+ */
+public class Echo<A> implements Fn2<Integer, Iterable<A>, Iterable<A>> {
+
+    private static final Echo<?> INSTANCE = new Echo<>();
+
+    private Echo() {
+    }
+
+    @Override
+    public Iterable<A> checkedApply(Integer n, Iterable<A> as) throws Throwable {
+        return flatten(map(replicate(n), as));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> Echo<A> echo() {
+        return (Echo<A>) INSTANCE;
+    }
+
+    public static <A> Fn1<Iterable<A>, Iterable<A>> echo(Integer n) {
+        return $(echo(), n);
+    }
+
+    public static <A> Iterable<A> echo(Integer n, Iterable<A> as) {
+        return $(echo(n), as);
+    }
+}

--- a/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/Nth.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/builtin/fn2/Nth.java
@@ -1,0 +1,43 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Head.head;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Drop.drop;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.$.$;
+
+/**
+ * Retrieve the element of an <code>{@link Iterable}&lt;A&gt;</code> found at ordinal index <code>k</code>
+ * wrapped in an {@link Maybe}. If the index <code>k</code> is greater than or equal to the size of the
+ * {@link Iterable}, the result is {@link Maybe#nothing()}.
+ *
+ * @param <A> the Iterable element type
+ */
+public class Nth<A> implements Fn2<Integer, Iterable<A>, Maybe<A>> {
+
+    private static final Nth<?> INSTANCE = new Nth<>();
+
+    private Nth() {
+    }
+
+    @Override
+    public Maybe<A> checkedApply(Integer k, Iterable<A> as) throws Throwable {
+        return k <= 0 ? nothing() : head(drop(k - 1, as));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A> Nth<A> nth() {
+        return (Nth<A>) INSTANCE;
+    }
+
+    public static <A> Fn1<Iterable<A>, Maybe<A>> nth(Integer k) {
+        return $(nth(), k);
+    }
+
+    public static <A> Maybe<A> nth(Integer k, Iterable<A> as) {
+        return $(nth(k), as);
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn0/NaturalNumbersTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn0/NaturalNumbersTest.java
@@ -1,0 +1,34 @@
+package com.jnape.palatable.lambda.functions.builtin.fn0;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn0.NaturalNumbers.naturalNumbers;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Drop.drop;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+import static org.junit.Assert.*;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static testsupport.matchers.IterableMatcher.iterates;
+
+public class NaturalNumbersTest {
+    @Test
+    public void producesTheNats() {
+        Iterable<Integer> numbers = naturalNumbers();
+        assertThat(take(10, numbers), iterates(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    }
+
+    @Test
+    public void producesNatsForever() {
+        Iterable<Integer> numbers = naturalNumbers();
+        assertThat(take(10, drop(STACK_EXPLODING_NUMBER, numbers)),
+                   iterates(STACK_EXPLODING_NUMBER + 1,
+                            STACK_EXPLODING_NUMBER + 2,
+                            STACK_EXPLODING_NUMBER + 3,
+                            STACK_EXPLODING_NUMBER + 4,
+                            STACK_EXPLODING_NUMBER + 5,
+                            STACK_EXPLODING_NUMBER + 6,
+                            STACK_EXPLODING_NUMBER + 7,
+                            STACK_EXPLODING_NUMBER + 8,
+                            STACK_EXPLODING_NUMBER + 9,
+                            STACK_EXPLODING_NUMBER + 10));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/IndexTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn1/IndexTest.java
@@ -1,0 +1,18 @@
+package com.jnape.palatable.lambda.functions.builtin.fn1;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Index.index;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Replicate.replicate;
+import static org.junit.Assert.*;
+import static testsupport.matchers.IterableMatcher.iterates;
+
+public class IndexTest {
+
+    @Test
+    public void indexes() {
+        Iterable<Character> as = replicate(5, 'a');
+        assertThat(index(as), iterates(tuple(1, 'a'), tuple(2, 'a'), tuple(3, 'a'), tuple(4, 'a'), tuple(5, 'a')));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/EchoTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/EchoTest.java
@@ -1,0 +1,27 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Drop.drop;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Echo.echo;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Iterate.iterate;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+import static testsupport.matchers.IterableMatcher.iterates;
+
+public class EchoTest {
+
+    @Test
+    public void echoesEachElement() {
+        Iterable<Integer> numbers = iterate(x -> x + 1, 1);
+        assertThat(take(9, echo(3, numbers)), iterates(1, 1, 1, 2, 2, 2, 3, 3, 3));
+    }
+
+    @Test
+    public void echoesEachElementForever() {
+        Iterable<Integer> numbers = iterate(x -> x + 1, 1);
+        assertThat(take(3, drop(3 * (STACK_EXPLODING_NUMBER - 1), echo(3, numbers))),
+                   iterates(STACK_EXPLODING_NUMBER, STACK_EXPLODING_NUMBER, STACK_EXPLODING_NUMBER));
+    }
+}

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/NthTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/NthTest.java
@@ -1,0 +1,45 @@
+package com.jnape.palatable.lambda.functions.builtin.fn2;
+
+import org.junit.Test;
+
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.functions.builtin.fn0.NaturalNumbers.naturalNumbers;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Nth.nth;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Take.take;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static testsupport.Constants.STACK_EXPLODING_NUMBER;
+
+public class NthTest {
+    @Test
+    public void negativeNthIsNothing() {
+        assertThat(nth(-5, naturalNumbers()), equalTo(nothing()));
+    }
+
+    @Test
+    public void zerothIsNothing() {
+        assertThat(nth(0, naturalNumbers()), equalTo(nothing()));
+    }
+
+    @Test
+    public void nthFromEmpty() {
+        assertThat(nth(5, emptyList()), equalTo(nothing()));
+    }
+
+    @Test
+    public void nthAfterEnd() {
+        assertThat(nth(5, take(3, naturalNumbers())), equalTo(nothing()));
+    }
+
+    @Test
+    public void nthWithinRange() {
+        assertThat(nth(5, take(10, naturalNumbers())), equalTo(just(5)));
+    }
+
+    @Test
+    public void largeNthFromInfinite() {
+        assertThat(nth(STACK_EXPLODING_NUMBER, naturalNumbers()), equalTo(just(STACK_EXPLODING_NUMBER)));
+    }
+}


### PR DESCRIPTION
Implement four new function for working with Iterables:

- NaturalNumbers: emits the sequence of natural numbers
- Index: pairs each element of an Iterable with its ordinal position
- Nth: retrieve the element at ordinal position n in an Iterable
- Echo: repeat each element of an Iterable k times

These are the Iterable analogues to the NaturalNumbersM, IndexM, NthM, and EchoM functions that I've implemented in a pull request on winterbourne.