### PR TITLE
Loosen EitherMatcher types, add static constructors

### DIFF
--- a/src/test/java/testsupport/matchers/EitherMatcher.java
+++ b/src/test/java/testsupport/matchers/EitherMatcher.java
@@ -9,11 +9,12 @@ import static com.jnape.palatable.lambda.adt.Either.left;
 import static com.jnape.palatable.lambda.adt.Either.right;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
 import static com.jnape.palatable.lambda.io.IO.io;
+import static org.hamcrest.CoreMatchers.anything;
 
 public final class EitherMatcher<L, R> extends TypeSafeMatcher<Either<L, R>> {
-    private final Either<Matcher<L>, Matcher<R>> matcher;
+    private final Either<Matcher<? super L>, Matcher<? super R>> matcher;
 
-    private EitherMatcher(Either<Matcher<L>, Matcher<R>> matcher) {
+    private EitherMatcher(Either<Matcher<? super L>, Matcher<? super R>> matcher) {
         this.matcher = matcher;
     }
 
@@ -44,11 +45,19 @@ public final class EitherMatcher<L, R> extends TypeSafeMatcher<Either<L, R>> {
             .unsafePerformIO();
     }
 
-    public static <L, R> EitherMatcher<L, R> isLeftThat(Matcher<L> lMatcher) {
+    public static <L, R> EitherMatcher<L, R> isLeftThat(Matcher<? super L> lMatcher) {
         return new EitherMatcher<>(left(lMatcher));
     }
 
-    public static <L, R> EitherMatcher<L, R> isRightThat(Matcher<R> rMatcher) {
+    public static <L, R> EitherMatcher<L, R> isLeft() {
+        return isLeftThat(anything());
+    }
+
+    public static <L, R> EitherMatcher<L, R> isRightThat(Matcher<? super R> rMatcher) {
         return new EitherMatcher<>(right(rMatcher));
+    }
+
+    public static <L, R> EitherMatcher<L, R> isRight() {
+        return isRightThat(anything());
     }
 }


### PR DESCRIPTION
Add isRight() and isLeft() matcher constructors to EitherMatcher. To implement these using the anything() core
matcher as the inner matcher, the type signature in isRightThat(..) and isLeftThat(..) has to be loosened since
this and some other core matchers are not strictly typed with parameterized types.

Resubmit of #113 