### PR TITLE
Absent folds short-circuit

### DIFF
--- a/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/AbsentTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/AbsentTest.java
@@ -1,10 +1,14 @@
 package com.jnape.palatable.lambda.semigroup.builtin;
 
+import com.jnape.palatable.lambda.adt.Unit;
+import com.jnape.palatable.lambda.functions.builtin.fn1.Constantly;
 import com.jnape.palatable.lambda.semigroup.Semigroup;
 import org.junit.Test;
 
 import static com.jnape.palatable.lambda.adt.Maybe.just;
 import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.adt.Unit.UNIT;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
 import static com.jnape.palatable.lambda.semigroup.builtin.Absent.absent;
 import static org.junit.Assert.assertEquals;
 
@@ -19,5 +23,25 @@ public class AbsentTest {
         assertEquals(nothing(), absent.apply(addition, nothing(), just(1)));
         assertEquals(nothing(), absent.apply(addition, just(1), nothing()));
         assertEquals(nothing(), absent.apply(addition, nothing(), nothing()));
+    }
+
+    @Test(timeout = 100)
+    public void foldRightShortCircuit() {
+        Absent.<Unit>absent(Constantly::constantly).foldRight(nothing(), repeat(just(UNIT))).value();
+    }
+
+    @Test(timeout = 100)
+    public void foldLeftShortCircuit() {
+        Absent.<Unit>absent(Constantly::constantly).foldLeft(nothing(), repeat(just(UNIT)));
+    }
+
+    @Test(timeout = 100)
+    public void checkedApplyFoldRightShortCircuit() {
+        Absent.<Unit>absent().checkedApply(Constantly::constantly).foldRight(nothing(), repeat(just(UNIT))).value();
+    }
+
+    @Test(timeout = 100)
+    public void checkedApplyFoldLeftShortCircuit() {
+        Absent.<Unit>absent().checkedApply(Constantly::constantly).foldLeft(nothing(), repeat(just(UNIT)));
     }
 }

--- a/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/AbsentTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/AbsentTest.java
@@ -1,9 +1,12 @@
 package com.jnape.palatable.lambda.semigroup.builtin;
 
+import com.jnape.palatable.lambda.adt.Maybe;
 import com.jnape.palatable.lambda.adt.Unit;
 import com.jnape.palatable.lambda.functions.builtin.fn1.Constantly;
 import com.jnape.palatable.lambda.semigroup.Semigroup;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 import static com.jnape.palatable.lambda.adt.Maybe.just;
 import static com.jnape.palatable.lambda.adt.Maybe.nothing;
@@ -25,23 +28,69 @@ public class AbsentTest {
         assertEquals(nothing(), absent.apply(addition, nothing(), nothing()));
     }
 
-    @Test(timeout = 100)
+    @Test
+    public void foldRight() {
+        Absent<Integer>    absent   = absent();
+        Semigroup<Integer> addition = Integer::sum;
+
+        assertEquals(just(3), absent.apply(addition).foldRight(just(0), Arrays.asList(just(1), just(2))).value());
+        assertEquals(nothing(), absent.apply(addition).foldRight(just(0), Arrays.asList(nothing(), just(1))).value());
+        assertEquals(nothing(), absent.apply(addition).foldRight(just(0), Arrays.asList(just(1), nothing())).value());
+        assertEquals(nothing(), absent.apply(addition).foldRight(just(0), Arrays.asList(nothing(), nothing())).value());
+    }
+
+    @Test
+    public void foldLeft() {
+        Absent<Integer>    absent   = absent();
+        Semigroup<Integer> addition = Integer::sum;
+
+        assertEquals(just(3), absent.apply(addition).foldLeft(just(0), Arrays.asList(just(1), just(2))));
+        assertEquals(nothing(), absent.apply(addition).foldLeft(just(0), Arrays.asList(nothing(), just(1))));
+        assertEquals(nothing(), absent.apply(addition).foldLeft(just(0), Arrays.asList(just(1), nothing())));
+        assertEquals(nothing(), absent.apply(addition).foldLeft(just(0), Arrays.asList(nothing(), nothing())));
+    }
+
+    @Test(timeout = 200)
     public void foldRightShortCircuit() {
-        Absent.<Unit>absent(Constantly::constantly).foldRight(nothing(), repeat(just(UNIT))).value();
+        Maybe<Unit> result = Absent.<Unit>absent(Constantly::constantly)
+                .foldRight(just(UNIT), repeat(nothing())).value();
+        assertEquals(nothing(), result);
+
+        result = Absent.<Unit>absent(Constantly::constantly)
+                .foldRight(nothing(), repeat(just(UNIT))).value();
+        assertEquals(nothing(), result);
     }
 
-    @Test(timeout = 100)
+    @Test(timeout = 200)
     public void foldLeftShortCircuit() {
-        Absent.<Unit>absent(Constantly::constantly).foldLeft(nothing(), repeat(just(UNIT)));
+        Maybe<Unit> result = Absent.<Unit>absent(Constantly::constantly)
+                .foldLeft(just(UNIT), repeat(nothing()));
+        assertEquals(nothing(), result);
+
+        result = Absent.<Unit>absent(Constantly::constantly)
+                .foldLeft(nothing(), repeat(just(UNIT)));
+        assertEquals(nothing(), result);
     }
 
-    @Test(timeout = 100)
+    @Test(timeout = 200)
     public void checkedApplyFoldRightShortCircuit() {
-        Absent.<Unit>absent().checkedApply(Constantly::constantly).foldRight(nothing(), repeat(just(UNIT))).value();
+        Maybe<Unit> result = Absent.<Unit>absent().checkedApply(Constantly::constantly)
+                .foldRight(just(UNIT), repeat(nothing())).value();
+        assertEquals(nothing(), result);
+
+        result = Absent.<Unit>absent().checkedApply(Constantly::constantly)
+                .foldRight(nothing(), repeat(just(UNIT))).value();
+        assertEquals(nothing(), result);
     }
 
-    @Test(timeout = 100)
+    @Test(timeout = 200)
     public void checkedApplyFoldLeftShortCircuit() {
-        Absent.<Unit>absent().checkedApply(Constantly::constantly).foldLeft(nothing(), repeat(just(UNIT)));
+        Maybe<Unit> result = Absent.<Unit>absent().checkedApply(Constantly::constantly)
+                .foldLeft(just(UNIT), repeat(nothing()));
+        assertEquals(nothing(), result);
+
+        result = Absent.<Unit>absent().checkedApply(Constantly::constantly)
+                .foldLeft(nothing(), repeat(just(UNIT)));
+        assertEquals(nothing(), result);
     }
 }


### PR DESCRIPTION
Reason: https://github.com/palatable/lambda/issues/115

Implementation:
* To ensure we always use the short-circuit semigroup I had to create a helper function `shortCircuitSemigroup` and use it in two different methods in Absent.
* Since short-circuit could alter the outcome of the results I added some tests to check that folds behavior hasn't changed (foldRight, foldLeft)
* Since we have two ways to exposing a semigroup in Absent I created tests for each of those (foldRightShortCircuit, checkedApplyFoldRightShortCircuit and foldLeftShortCircuit, checkedApplyFoldLeftShortCircuit)
* I am considering two checks in the short-circuit tests. When accumulator is nothing and the infinate iterable is repeats just(UNIT) and when the accumulator is just(UNIT) and the infinite iterable repeats nothing()