### PR TITLE
New utility methods on MonadReader and simple implementation of Reader.

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/functions/Fn1.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/Fn1.java
@@ -121,6 +121,14 @@ public interface Fn1<A, B> extends
     default <C> Fn1<A, C> flatMap(Fn1<? super B, ? extends Monad<C, Fn1<A, ?>>> f) {
         return a -> f.apply(apply(a)).<Fn1<A, C>>coerce().apply(a);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default <C> Fn1<A, C> rflatMap(Fn2<? super A, ? super B, ? extends MonadReader<A, C, Fn1<A, ?>>> f) {
+    	return a -> f.apply(a, apply(a)).<Fn1<A, C>>coerce().apply(a);
+    }
 
     /**
      * Left-to-right composition.

--- a/src/main/java/com/jnape/palatable/lambda/functions/Fn1.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/Fn1.java
@@ -121,7 +121,7 @@ public interface Fn1<A, B> extends
     default <C> Fn1<A, C> flatMap(Fn1<? super B, ? extends Monad<C, Fn1<A, ?>>> f) {
         return a -> f.apply(apply(a)).<Fn1<A, C>>coerce().apply(a);
     }
-    
+
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/jnape/palatable/lambda/functions/specialized/Pure.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/specialized/Pure.java
@@ -18,8 +18,7 @@ public interface Pure<F extends Functor<?, ? extends F>> {
 
     default <A, FA extends Functor<A, ? extends F>> FA apply(A a) {
         try {
-            @SuppressWarnings("unchecked") FA fa = downcast(checkedApply(a));
-            return fa;
+            return downcast(this.<A>checkedApply(a));
         } catch (Throwable t) {
             throw Runtime.throwChecked(t);
         }

--- a/src/main/java/com/jnape/palatable/lambda/functor/builtin/Reader.java
+++ b/src/main/java/com/jnape/palatable/lambda/functor/builtin/Reader.java
@@ -25,188 +25,183 @@ import com.jnape.palatable.lambda.monad.MonadRec;
  * @param <A> the embedded output type
  */
 public class Reader<R, A>
-		implements MonadReader<R, A, Reader<R, ?>>, Cartesian<R, A, Reader<?, ?>>, MonadRec<A, Reader<R, ?>> {
-	private final Fn1<? super R, ? extends Tuple2<A, R>> readerFn;
+        implements MonadReader<R, A, Reader<R, ?>>, Cartesian<R, A, Reader<?, ?>>, MonadRec<A, Reader<R, ?>> {
+    private final Fn1<? super R, ? extends Tuple2<A, R>> readerFn;
 
-	public Reader(Fn1<? super R, ? extends Tuple2<A, R>> f) {
-		this.readerFn = f;
-	}
+    public Reader(Fn1<? super R, ? extends Tuple2<A, R>> f) {
+        this.readerFn = f;
+    }
 
-	public Tuple2<A, R> run(R r) {
-		return readerFn.apply(r);
-	}
+    public Tuple2<A, R> run(R r) {
+        return readerFn.apply(r);
+    }
 
-	public A eval(R r) {
-		return run(r)._1();
-	}
+    public A eval(R r) {
+        return run(r)._1();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public Reader<R, A> local(Fn1<? super R, ? extends R> fn) {
-		return reader(r -> eval(fn.apply(r)));
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Reader<R, B> fmap(Fn1<? super A, ? extends B> fn) {
-		return MonadRec.super.<B>fmap(fn).coerce();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Reader<R, B> zip(Applicative<Fn1<? super A, ? extends B>, Reader<R, ?>> appFn) {
-		return MonadRec.super.zip(appFn).coerce();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Lazy<Reader<R, B>> lazyZip(
-			Lazy<? extends Applicative<Fn1<? super A, ? extends B>, Reader<R, ?>>> lazyAppFn) {
-		return MonadRec.super.lazyZip(lazyAppFn).fmap(MonadRec<B, Reader<R, ?>>::coerce);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Reader<R, B> flatMap(Fn1<? super A, ? extends Monad<B, Reader<R, ?>>> f) {
-		return reader(r -> f.apply(eval(r)).<Reader<R, B>>coerce().eval(r));
-	}
-
-	 /**
+    /**
      * {@inheritDoc}
      */
-	@Override
-	public <B> Reader<R, B> rflatMap(Fn2<? super R, ? super A, ? extends MonadReader<R, B, Reader<R, ?>>> f) {
-		return reader(r -> f.apply(r, eval(r)).<Reader<R, B>>coerce().eval(r));
-	}
+    @Override
+    public Reader<R, A> local(Fn1<? super R, ? extends R> fn) {
+        return reader(r -> eval(fn.apply(r)));
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Reader<R, B> pure(B b) {
-		return reader(r -> b);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<R, B> fmap(Fn1<? super A, ? extends B> fn) {
+        return MonadRec.super.<B>fmap(fn).coerce();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Reader<R, B> trampolineM(Fn1<? super A, ? extends MonadRec<RecursiveResult<A, B>, Reader<R, ?>>> fn) {
-		return new Reader<>(
-				fn1(this::run).fmap(trampoline(into((a, r) -> fn.apply(a).<Reader<R, RecursiveResult<A, B>>>coerce()
-						.run(r).into((aOrB, r_) -> aOrB.biMap(a_ -> tuple(a_, r_), b -> tuple(b, r_)))))));
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<R, B> zip(Applicative<Fn1<? super A, ? extends B>, Reader<R, ?>> appFn) {
+        return MonadRec.super.zip(appFn).coerce();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Reader<R, B> discardL(Applicative<B, Reader<R, ?>> appB) {
-		return MonadRec.super.discardL(appB).coerce();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Lazy<Reader<R, B>> lazyZip(
+            Lazy<? extends Applicative<Fn1<? super A, ? extends B>, Reader<R, ?>>> lazyAppFn) {
+        return MonadRec.super.lazyZip(lazyAppFn).fmap(MonadRec<B, Reader<R, ?>>::coerce);
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Reader<R, A> discardR(Applicative<B, Reader<R, ?>> appB) {
-		return MonadRec.super.discardR(appB).coerce();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<R, B> flatMap(Fn1<? super A, ? extends Monad<B, Reader<R, ?>>> f) {
+        return reader(r -> f.apply(eval(r)).<Reader<R, B>>coerce().eval(r));
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Reader<Tuple2<B, R>, Tuple2<B, A>> cartesian() {
-		return new Reader<>(t -> run(t._2()).fmap(tupler(t._1())).biMapL(tupler(t._1())));
-	}
+     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<R, B> rflatMap(Fn2<? super R, ? super A, ? extends MonadReader<R, B, Reader<R, ?>>> f) {
+        return reader(r -> f.apply(r, eval(r)).<Reader<R, B>>coerce().eval(r));
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <Z, C> Reader<Z, C> diMap(Fn1<? super Z, ? extends R> lFn, Fn1<? super A, ? extends C> rFn) {
-		return reader(z -> run(lFn.apply(z)).biMapL(rFn)._1());
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<R, B> pure(B b) {
+        return reader(r -> b);
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <Q> Reader<Q, A> diMapL(Fn1<? super Q, ? extends R> fn) {
-		return (Reader<Q, A>) Cartesian.super.<Q>diMapL(fn);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<R, B> trampolineM(Fn1<? super A, ? extends MonadRec<RecursiveResult<A, B>, Reader<R, ?>>> fn) {
+        return new Reader<>(
+                fn1(this::run).fmap(trampoline(into((a, r) -> fn.apply(a).<Reader<R, RecursiveResult<A, B>>>coerce()
+                        .run(r).into((aOrB, r_) -> aOrB.biMap(a_ -> tuple(a_, r_), b -> tuple(b, r_)))))));
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> Reader<R, B> diMapR(Fn1<? super A, ? extends B> fn) {
-		return (Reader<R, B>) Cartesian.super.<B>diMapR(fn);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<R, B> discardL(Applicative<B, Reader<R, ?>> appB) {
+        return MonadRec.super.discardL(appB).coerce();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <Q> Reader<Q, A> contraMap(Fn1<? super Q, ? extends R> fn) {
-		return (Reader<Q, A>) Cartesian.super.<Q>contraMap(fn);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<R, A> discardR(Applicative<B, Reader<R, ?>> appB) {
+        return MonadRec.super.discardR(appB).coerce();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public Reader<R, Tuple2<R, A>> carry() {
-		return (Reader<R, Tuple2<R, A>>) Cartesian.super.carry();
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<Tuple2<B, R>, Tuple2<B, A>> cartesian() {
+        return new Reader<>(t -> run(t._2()).fmap(tupler(t._1())).biMapL(tupler(t._1())));
+    }
 
-	/**
-	 * Construct a {@link Reader} from a value.
-	 *
-	 * @param a   the output value
-	 * @param <W> the accumulation type
-	 * @param <A> the value type
-	 * @return the {@link Writer}
-	 */
-	public static <R, A> Reader<R, A> listen(A a) {
-		return reader(r -> a);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <Z, C> Reader<Z, C> diMap(Fn1<? super Z, ? extends R> lFn, Fn1<? super A, ? extends C> rFn) {
+        return reader(z -> run(lFn.apply(z)).biMapL(rFn)._1());
+    }
 
-	/**
-	 * Lift a {@link Fn1 function} into a {@link Reader} instance.
-	 *
-	 * @param fn  the function
-	 * @param <R> the input type
-	 * @param <A> the embedded output type
-	 * @return the {@link Reader}
-	 */
-	public static <R, A> Reader<R, A> reader(Fn1<? super R, ? extends A> fn) {
-		return new Reader<>(r -> tuple(fn.apply(r), r));
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <Q> Reader<Q, A> diMapL(Fn1<? super Q, ? extends R> fn) {
+        return (Reader<Q, A>) Cartesian.super.<Q>diMapL(fn);
+    }
 
-	/**
-	 * The canonical {@link Pure} instance for {@link Reader}.
-	 *
-	 * @param <R> the input type
-	 * @return the {@link Pure} instance
-	 */
-	public static <R> Pure<Reader<R, ?>> pureReader() {
-		return new Pure<Reader<R, ?>>() {
-			@Override
-			public <A> Reader<R, A> checkedApply(A a) {
-				return listen(a);
-			}
-		};
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> Reader<R, B> diMapR(Fn1<? super A, ? extends B> fn) {
+        return (Reader<R, B>) Cartesian.super.<B>diMapR(fn);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <Q> Reader<Q, A> contraMap(Fn1<? super Q, ? extends R> fn) {
+        return (Reader<Q, A>) Cartesian.super.<Q>contraMap(fn);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Reader<R, Tuple2<R, A>> carry() {
+        return (Reader<R, Tuple2<R, A>>) Cartesian.super.carry();
+    }
+
+    /**
+     * Construct a {@link Reader} from a value.
+     *
+     * @param a   the output value
+     * @param <W> the accumulation type
+     * @param <A> the value type
+     * @return the {@link Writer}
+     */
+    public static <R, A> Reader<R, A> listen(A a) {
+        return reader(r -> a);
+    }
+
+    /**
+     * Lift a {@link Fn1 function} into a {@link Reader} instance.
+     *
+     * @param fn  the function
+     * @param <R> the input type
+     * @param <A> the embedded output type
+     * @return the {@link Reader}
+     */
+    public static <R, A> Reader<R, A> reader(Fn1<? super R, ? extends A> fn) {
+        return new Reader<>(r -> tuple(fn.apply(r), r));
+    }
+
+    /**
+     * The canonical {@link Pure} instance for {@link Reader}.
+     *
+     * @param <R> the input type
+     * @return the {@link Pure} instance
+     */
+    public static <R> Pure<Reader<R, ?>> pureReader() {
+        return Reader::listen;
+    }
 }

--- a/src/main/java/com/jnape/palatable/lambda/functor/builtin/Reader.java
+++ b/src/main/java/com/jnape/palatable/lambda/functor/builtin/Reader.java
@@ -1,0 +1,212 @@
+package com.jnape.palatable.lambda.functor.builtin;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.Fn1.fn1;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Tupler2.tupler;
+import static com.jnape.palatable.lambda.functions.recursion.Trampoline.trampoline;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
+import com.jnape.palatable.lambda.functions.recursion.RecursiveResult;
+import com.jnape.palatable.lambda.functions.specialized.Pure;
+import com.jnape.palatable.lambda.functor.Applicative;
+import com.jnape.palatable.lambda.functor.Cartesian;
+import com.jnape.palatable.lambda.monad.Monad;
+import com.jnape.palatable.lambda.monad.MonadReader;
+import com.jnape.palatable.lambda.monad.MonadRec;
+
+/**
+ * The lazy reader monad, a monad for any {@link Fn1 function} from some
+ * environment of type <code>R</code>.
+ *
+ * @param <R> the environment type
+ * @param <A> the embedded output type
+ */
+public class Reader<R, A>
+		implements MonadReader<R, A, Reader<R, ?>>, Cartesian<R, A, Reader<?, ?>>, MonadRec<A, Reader<R, ?>> {
+	private final Fn1<? super R, ? extends Tuple2<A, R>> readerFn;
+
+	public Reader(Fn1<? super R, ? extends Tuple2<A, R>> f) {
+		this.readerFn = f;
+	}
+
+	public Tuple2<A, R> run(R r) {
+		return readerFn.apply(r);
+	}
+
+	public A eval(R r) {
+		return run(r)._1();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Reader<R, A> local(Fn1<? super R, ? extends R> fn) {
+		return reader(r -> eval(fn.apply(r)));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Reader<R, B> fmap(Fn1<? super A, ? extends B> fn) {
+		return MonadRec.super.<B>fmap(fn).coerce();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Reader<R, B> zip(Applicative<Fn1<? super A, ? extends B>, Reader<R, ?>> appFn) {
+		return MonadRec.super.zip(appFn).coerce();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Lazy<Reader<R, B>> lazyZip(
+			Lazy<? extends Applicative<Fn1<? super A, ? extends B>, Reader<R, ?>>> lazyAppFn) {
+		return MonadRec.super.lazyZip(lazyAppFn).fmap(MonadRec<B, Reader<R, ?>>::coerce);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Reader<R, B> flatMap(Fn1<? super A, ? extends Monad<B, Reader<R, ?>>> f) {
+		return reader(r -> f.apply(eval(r)).<Reader<R, B>>coerce().eval(r));
+	}
+
+	 /**
+     * {@inheritDoc}
+     */
+	@Override
+	public <B> Reader<R, B> rflatMap(Fn2<? super R, ? super A, ? extends MonadReader<R, B, Reader<R, ?>>> f) {
+		return reader(r -> f.apply(r, eval(r)).<Reader<R, B>>coerce().eval(r));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Reader<R, B> pure(B b) {
+		return reader(r -> b);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Reader<R, B> trampolineM(Fn1<? super A, ? extends MonadRec<RecursiveResult<A, B>, Reader<R, ?>>> fn) {
+		return new Reader<>(
+				fn1(this::run).fmap(trampoline(into((a, r) -> fn.apply(a).<Reader<R, RecursiveResult<A, B>>>coerce()
+						.run(r).into((aOrB, r_) -> aOrB.biMap(a_ -> tuple(a_, r_), b -> tuple(b, r_)))))));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Reader<R, B> discardL(Applicative<B, Reader<R, ?>> appB) {
+		return MonadRec.super.discardL(appB).coerce();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Reader<R, A> discardR(Applicative<B, Reader<R, ?>> appB) {
+		return MonadRec.super.discardR(appB).coerce();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Reader<Tuple2<B, R>, Tuple2<B, A>> cartesian() {
+		return new Reader<>(t -> run(t._2()).fmap(tupler(t._1())).biMapL(tupler(t._1())));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <Z, C> Reader<Z, C> diMap(Fn1<? super Z, ? extends R> lFn, Fn1<? super A, ? extends C> rFn) {
+		return reader(z -> run(lFn.apply(z)).biMapL(rFn)._1());
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <Q> Reader<Q, A> diMapL(Fn1<? super Q, ? extends R> fn) {
+		return (Reader<Q, A>) Cartesian.super.<Q>diMapL(fn);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> Reader<R, B> diMapR(Fn1<? super A, ? extends B> fn) {
+		return (Reader<R, B>) Cartesian.super.<B>diMapR(fn);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <Q> Reader<Q, A> contraMap(Fn1<? super Q, ? extends R> fn) {
+		return (Reader<Q, A>) Cartesian.super.<Q>contraMap(fn);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Reader<R, Tuple2<R, A>> carry() {
+		return (Reader<R, Tuple2<R, A>>) Cartesian.super.carry();
+	}
+
+	/**
+	 * Construct a {@link Reader} from a value.
+	 *
+	 * @param a   the output value
+	 * @param <W> the accumulation type
+	 * @param <A> the value type
+	 * @return the {@link Writer}
+	 */
+	public static <R, A> Reader<R, A> listen(A a) {
+		return reader(r -> a);
+	}
+
+	/**
+	 * Lift a {@link Fn1 function} into a {@link Reader} instance.
+	 *
+	 * @param fn  the function
+	 * @param <R> the input type
+	 * @param <A> the embedded output type
+	 * @return the {@link Reader}
+	 */
+	public static <R, A> Reader<R, A> reader(Fn1<? super R, ? extends A> fn) {
+		return new Reader<>(r -> tuple(fn.apply(r), r));
+	}
+
+	/**
+	 * The canonical {@link Pure} instance for {@link Reader}.
+	 *
+	 * @param <R> the input type
+	 * @return the {@link Pure} instance
+	 */
+	public static <R> Pure<Reader<R, ?>> pureReader() {
+		return new Pure<Reader<R, ?>>() {
+			@Override
+			public <A> Reader<R, A> checkedApply(A a) {
+				return listen(a);
+			}
+		};
+	}
+}

--- a/src/main/java/com/jnape/palatable/lambda/functor/builtin/State.java
+++ b/src/main/java/com/jnape/palatable/lambda/functor/builtin/State.java
@@ -3,6 +3,7 @@ package com.jnape.palatable.lambda.functor.builtin;
 import com.jnape.palatable.lambda.adt.Unit;
 import com.jnape.palatable.lambda.adt.hlist.Tuple2;
 import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
 import com.jnape.palatable.lambda.functions.recursion.RecursiveResult;
 import com.jnape.palatable.lambda.functions.specialized.Pure;
 import com.jnape.palatable.lambda.functor.Applicative;
@@ -123,6 +124,14 @@ public final class State<S, A> implements
     @Override
     public <B> State<S, B> flatMap(Fn1<? super A, ? extends Monad<B, State<S, ?>>> f) {
         return state(s -> run(s).into((a, s2) -> f.apply(a).<State<S, B>>coerce().run(s2)));
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> State<S, B> rflatMap(Fn2<? super S, ? super A, ? extends MonadReader<S, B, State<S, ?>>> f) {
+    	return state(s -> run(s).into((a, s2) -> f.apply(s, a).<State<S, B>>coerce().run(s2)));
     }
 
     /**

--- a/src/main/java/com/jnape/palatable/lambda/monad/MonadReader.java
+++ b/src/main/java/com/jnape/palatable/lambda/monad/MonadReader.java
@@ -43,51 +43,50 @@ public interface MonadReader<R, A, MR extends MonadReader<R, ?, MR>> extends Mon
      */
     @Override
     <B> MonadReader<R, B, MR> pure(B b);
-	
-	/**
-	 * Using both the environment and the current output, chain dependent
-	 * computations that may continue or short-circuit based on previous results.
-	 *
-	 * @param fn  the dependent computation over R and A
-	 * @param <B> the resulting Reader parameter type
-	 * @return the new Reader instance
-	 */
-	<B> MonadReader<R, B, MR> rflatMap(Fn2<? super R, ? super A, ? extends MonadReader<R, B, MR>> fn);
 
-
-	/**
-	 * Using both the environment and the current output, chain dependent
-	 * computations that may continue or short-circuit based on previous results.
-	 *
-	 * @param fn  the dependent computation over R and A
-	 * @param <B> the resulting Reader parameter type
-	 * @return the new Reader instance
-	 */
-	default <B> MonadReader<R, B, MR> rflatMap(Fn1<Tuple2<? super A, ? super R>, ? extends MonadReader<R, B, MR>> fn) {
-		return rflatMap((r, a) -> fn.apply(tuple(a, r)));
-	}
-    
     /**
-	 * Map both the environment and the current output to a new output.
-	 *
-	 * @param fn  the mapping function
-	 * @param <B> the new state type
-	 * @return the mapped {@link MonadReader}
-	 */
-	default <B> MonadReader<R, B, MR> rmap(Fn2<? super R, ? super A, ? extends B> fn) {
-		return rflatMap((r, a) -> pure(fn.apply(r, a)));
-	}
-	
-	/**
-	 * Map both the environment and the current output to a new output.
-	 *
-	 * @param fn  the mapping function
-	 * @param <B> the new state type
-	 * @return the mapped {@link MonadReader}
-	 */
-	default <B> MonadReader<R, B, MR> rmap(Fn1<Tuple2<? super A, ? super R>, ? extends B> fn) {
-		return rflatMap((r, a) -> pure(fn.apply(tuple(a, r))));
-	}
+     * Using both the environment and the current output, chain dependent
+     * computations that may continue or short-circuit based on previous results.
+     *
+     * @param fn  the dependent computation over R and A
+     * @param <B> the resulting Reader parameter type
+     * @return the new Reader instance
+     */
+    <B> MonadReader<R, B, MR> rflatMap(Fn2<? super R, ? super A, ? extends MonadReader<R, B, MR>> fn);
+
+    /**
+     * Using both the environment and the current output, chain dependent
+     * computations that may continue or short-circuit based on previous results.
+     *
+     * @param fn  the dependent computation over R and A
+     * @param <B> the resulting Reader parameter type
+     * @return the new Reader instance
+     */
+    default <B> MonadReader<R, B, MR> rflatMap(Fn1<Tuple2<? super A, ? super R>, ? extends MonadReader<R, B, MR>> fn) {
+        return rflatMap((r, a) -> fn.apply(tuple(a, r)));
+    }
+
+    /**
+     * Map both the environment and the current output to a new output.
+     *
+     * @param fn  the mapping function
+     * @param <B> the new state type
+     * @return the mapped {@link MonadReader}
+     */
+    default <B> MonadReader<R, B, MR> rmap(Fn2<? super R, ? super A, ? extends B> fn) {
+        return rflatMap((r, a) -> pure(fn.apply(r, a)));
+    }
+
+    /**
+     * Map both the environment and the current output to a new output.
+     *
+     * @param fn  the mapping function
+     * @param <B> the new state type
+     * @return the mapped {@link MonadReader}
+     */
+    default <B> MonadReader<R, B, MR> rmap(Fn1<Tuple2<? super A, ? super R>, ? extends B> fn) {
+        return rflatMap((r, a) -> pure(fn.apply(tuple(a, r))));
+    }
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/jnape/palatable/lambda/monad/MonadReader.java
+++ b/src/main/java/com/jnape/palatable/lambda/monad/MonadReader.java
@@ -1,6 +1,10 @@
 package com.jnape.palatable.lambda.monad;
 
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
 import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
 import com.jnape.palatable.lambda.functor.Applicative;
 import com.jnape.palatable.lambda.functor.Contravariant;
 import com.jnape.palatable.lambda.functor.Profunctor;
@@ -39,6 +43,51 @@ public interface MonadReader<R, A, MR extends MonadReader<R, ?, MR>> extends Mon
      */
     @Override
     <B> MonadReader<R, B, MR> pure(B b);
+	
+	/**
+	 * Using both the environment and the current output, chain dependent
+	 * computations that may continue or short-circuit based on previous results.
+	 *
+	 * @param fn  the dependent computation over R and A
+	 * @param <B> the resulting Reader parameter type
+	 * @return the new Reader instance
+	 */
+	<B> MonadReader<R, B, MR> rflatMap(Fn2<? super R, ? super A, ? extends MonadReader<R, B, MR>> fn);
+
+
+	/**
+	 * Using both the environment and the current output, chain dependent
+	 * computations that may continue or short-circuit based on previous results.
+	 *
+	 * @param fn  the dependent computation over R and A
+	 * @param <B> the resulting Reader parameter type
+	 * @return the new Reader instance
+	 */
+	default <B> MonadReader<R, B, MR> rflatMap(Fn1<Tuple2<? super A, ? super R>, ? extends MonadReader<R, B, MR>> fn) {
+		return rflatMap((r, a) -> fn.apply(tuple(a, r)));
+	}
+    
+    /**
+	 * Map both the environment and the current output to a new output.
+	 *
+	 * @param fn  the mapping function
+	 * @param <B> the new state type
+	 * @return the mapped {@link MonadReader}
+	 */
+	default <B> MonadReader<R, B, MR> rmap(Fn2<? super R, ? super A, ? extends B> fn) {
+		return rflatMap((r, a) -> pure(fn.apply(r, a)));
+	}
+	
+	/**
+	 * Map both the environment and the current output to a new output.
+	 *
+	 * @param fn  the mapping function
+	 * @param <B> the new state type
+	 * @return the mapped {@link MonadReader}
+	 */
+	default <B> MonadReader<R, B, MR> rmap(Fn1<Tuple2<? super A, ? super R>, ? extends B> fn) {
+		return rflatMap((r, a) -> pure(fn.apply(tuple(a, r))));
+	}
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderT.java
+++ b/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderT.java
@@ -2,6 +2,7 @@ package com.jnape.palatable.lambda.monad.transformer.builtin;
 
 import com.jnape.palatable.lambda.adt.hlist.Tuple2;
 import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
 import com.jnape.palatable.lambda.functions.recursion.RecursiveResult;
 import com.jnape.palatable.lambda.functions.specialized.Lift;
 import com.jnape.palatable.lambda.functions.specialized.Pure;
@@ -96,6 +97,14 @@ public final class ReaderT<R, M extends MonadRec<?, M>, A> implements
     public <B> ReaderT<R, M, B> flatMap(Fn1<? super A, ? extends Monad<B, ReaderT<R, M, ?>>> f) {
         return readerT(r -> runReaderT(r).flatMap(a -> f.apply(a).<ReaderT<R, M, B>>coerce().runReaderT(r)));
     }
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <B> ReaderT<R, M, B> rflatMap(Fn2<? super R, ? super A, ? extends MonadReader<R, B, ReaderT<R, M, ?>>> f) {
+		return readerT(r -> runReaderT(r).flatMap(a -> f.apply(r, a).<ReaderT<R, M, B>>coerce().runReaderT(r)));
+	}
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderT.java
+++ b/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderT.java
@@ -97,14 +97,14 @@ public final class ReaderT<R, M extends MonadRec<?, M>, A> implements
     public <B> ReaderT<R, M, B> flatMap(Fn1<? super A, ? extends Monad<B, ReaderT<R, M, ?>>> f) {
         return readerT(r -> runReaderT(r).flatMap(a -> f.apply(a).<ReaderT<R, M, B>>coerce().runReaderT(r)));
     }
-	
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public <B> ReaderT<R, M, B> rflatMap(Fn2<? super R, ? super A, ? extends MonadReader<R, B, ReaderT<R, M, ?>>> f) {
-		return readerT(r -> runReaderT(r).flatMap(a -> f.apply(r, a).<ReaderT<R, M, B>>coerce().runReaderT(r)));
-	}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> ReaderT<R, M, B> rflatMap(Fn2<? super R, ? super A, ? extends MonadReader<R, B, ReaderT<R, M, ?>>> f) {
+        return readerT(r -> runReaderT(r).flatMap(a -> f.apply(r, a).<ReaderT<R, M, B>>coerce().runReaderT(r)));
+    }
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/StateT.java
+++ b/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/StateT.java
@@ -131,7 +131,7 @@ public final class StateT<S, M extends MonadRec<?, M>, A> implements
     public <B> StateT<S, M, B> flatMap(Fn1<? super A, ? extends Monad<B, StateT<S, M, ?>>> f) {
         return stateT(s -> runStateT(s).flatMap(into((a, s_) -> f.apply(a).<StateT<S, M, B>>coerce().runStateT(s_))));
     }
-    
+
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/StateT.java
+++ b/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/StateT.java
@@ -3,6 +3,7 @@ package com.jnape.palatable.lambda.monad.transformer.builtin;
 import com.jnape.palatable.lambda.adt.Unit;
 import com.jnape.palatable.lambda.adt.hlist.Tuple2;
 import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.Fn2;
 import com.jnape.palatable.lambda.functions.recursion.RecursiveResult;
 import com.jnape.palatable.lambda.functions.specialized.Lift;
 import com.jnape.palatable.lambda.functions.specialized.Pure;
@@ -129,6 +130,14 @@ public final class StateT<S, M extends MonadRec<?, M>, A> implements
     @Override
     public <B> StateT<S, M, B> flatMap(Fn1<? super A, ? extends Monad<B, StateT<S, M, ?>>> f) {
         return stateT(s -> runStateT(s).flatMap(into((a, s_) -> f.apply(a).<StateT<S, M, B>>coerce().runStateT(s_))));
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <B> MonadReader<S, B, StateT<S, M, ?>> rflatMap(Fn2<? super S, ? super A, ? extends MonadReader<S, B, StateT<S, M, ?>>> f) {
+    	return stateT(s -> runStateT(s).flatMap(into((a, s_) -> f.apply(s, a).<StateT<S, M, B>>coerce().runStateT(s_))));
     }
 
     /**

--- a/src/test/java/com/jnape/palatable/lambda/functor/builtin/ReaderTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functor/builtin/ReaderTest.java
@@ -1,0 +1,27 @@
+package com.jnape.palatable.lambda.functor.builtin;
+
+import static com.jnape.palatable.lambda.functor.builtin.Reader.listen;
+import static com.jnape.palatable.traitor.framework.Subjects.subjects;
+import static testsupport.traits.Equivalence.equivalence;
+
+import org.junit.runner.RunWith;
+
+import com.jnape.palatable.traitor.annotations.TestTraits;
+import com.jnape.palatable.traitor.framework.Subjects;
+import com.jnape.palatable.traitor.runners.Traits;
+
+import testsupport.traits.ApplicativeLaws;
+import testsupport.traits.Equivalence;
+import testsupport.traits.FunctorLaws;
+import testsupport.traits.MonadLaws;
+import testsupport.traits.MonadReaderLaws;
+import testsupport.traits.MonadRecLaws;
+
+@RunWith(Traits.class)
+public class ReaderTest {
+	@TestTraits({ FunctorLaws.class, ApplicativeLaws.class, MonadLaws.class, MonadRecLaws.class,
+			MonadReaderLaws.class })
+	public Subjects<Equivalence<Reader<String, ?>>> testSubject() {
+		return subjects(equivalence(listen("test"), reader -> reader.eval("test")));
+	}
+}

--- a/src/test/java/com/jnape/palatable/lambda/functor/builtin/ReaderTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functor/builtin/ReaderTest.java
@@ -19,9 +19,9 @@ import testsupport.traits.MonadRecLaws;
 
 @RunWith(Traits.class)
 public class ReaderTest {
-	@TestTraits({ FunctorLaws.class, ApplicativeLaws.class, MonadLaws.class, MonadRecLaws.class,
-			MonadReaderLaws.class })
-	public Subjects<Equivalence<Reader<String, ?>>> testSubject() {
-		return subjects(equivalence(listen("test"), reader -> reader.eval("test")));
-	}
+    @TestTraits({ FunctorLaws.class, ApplicativeLaws.class, MonadLaws.class, MonadRecLaws.class,
+            MonadReaderLaws.class })
+    public Subjects<Equivalence<Reader<String, ?>>> testSubject() {
+        return subjects(equivalence(listen("test"), reader -> reader.eval("test")));
+    }
 }


### PR DESCRIPTION
It is sometimes usefull to inspect the 'environment' while mapping the current value. Something similar is implemented by State#mapState(Fn1) but the implementation is somehow cumbersome when only inspection without modification of the 'environment' is needed.