### PR TITLE
Add ReaderT#ask

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderT.java
+++ b/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderT.java
@@ -213,7 +213,8 @@ public final class ReaderT<R, M extends MonadRec<?, M>, A> implements
      * @return the {@link ReaderT}
      */
     public static <R, M extends MonadRec<?, M>> ReaderT<R, M, R> ask(Pure<M> pureM) {
-        return readerT(pureM::apply);
+        //noinspection Convert2MethodRef
+        return readerT(a -> pureM.apply(a));
     }
 
     /**

--- a/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderT.java
+++ b/src/main/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderT.java
@@ -205,6 +205,18 @@ public final class ReaderT<R, M extends MonadRec<?, M>, A> implements
     }
 
     /**
+     * Given a {@link Pure} ask will give you access to the input within the monadic embedding
+     *
+     * @param pureM the {@link Pure} instance for the given {@link Monad}
+     * @param <R> the input and output type of the returned ReaderT
+     * @param <M> the returned {@link Monad}
+     * @return the {@link ReaderT}
+     */
+    public static <R, M extends MonadRec<?, M>> ReaderT<R, M, R> ask(Pure<M> pureM) {
+        return readerT(pureM::apply);
+    }
+
+    /**
      * Lift a {@link Fn1 function} (<code>R -&gt; {@link Monad}&lt;A, M&gt;</code>) into a {@link ReaderT} instance.
      *
      * @param fn  the function

--- a/src/test/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderTTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/monad/transformer/builtin/ReaderTTest.java
@@ -97,4 +97,11 @@ public class ReaderTTest {
         readerT.fmap(plusOne).fmap(plusOne).fmap(plusOne).runReaderT(0);
         assertEquals(1, invocations.get());
     }
+
+    @Test
+    public void askRetrievesInput() {
+        assertEquals(new Identity<>(1),
+                ReaderT.<Integer, Identity<?>>ask(pureIdentity())
+                        .<Identity<Integer>>runReaderT(1));
+    }
 }


### PR DESCRIPTION
I'm still not sure this is the right thing to add since it's so easy to pass `pure#apply` at the call site. It might be better to have an interface method on `MonadReader` so you don't need to pass the pure.