### PR TITLE
Fix DropWhile fusion bug

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterable.java
+++ b/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterable.java
@@ -1,20 +1,9 @@
 package com.jnape.palatable.lambda.internal.iteration;
 
 import com.jnape.palatable.lambda.functions.Fn1;
-import com.jnape.palatable.lambda.functions.builtin.fn2.DropWhile;
 import com.jnape.palatable.lambda.internal.ImmutableQueue;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
-
-import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
-import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
-import static com.jnape.palatable.lambda.functions.builtin.fn2.Any.any;
-import static com.jnape.palatable.lambda.functions.builtin.fn2.DropWhile.dropWhile;
-import static com.jnape.palatable.lambda.functions.builtin.fn3.Times.times;
-import static java.util.Collections.singletonList;
 
 public final class PredicatedDroppingIterable<A> implements Iterable<A> {
     private final ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates;

--- a/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterable.java
+++ b/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterable.java
@@ -1,17 +1,23 @@
 package com.jnape.palatable.lambda.internal.iteration;
 
 import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.functions.builtin.fn2.DropWhile;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Any.any;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.DropWhile.dropWhile;
+import static com.jnape.palatable.lambda.functions.builtin.fn3.Times.times;
 import static java.util.Collections.singletonList;
 
 public final class PredicatedDroppingIterable<A> implements Iterable<A> {
     private final List<Fn1<? super A, ? extends Boolean>> predicates;
-    private final Iterable<A>                             as;
+    private final Iterable<A> as;
 
     public PredicatedDroppingIterable(Fn1<? super A, ? extends Boolean> predicate, Iterable<A> as) {
         List<Fn1<? super A, ? extends Boolean>> predicates = new ArrayList<>(singletonList(predicate));
@@ -26,7 +32,6 @@ public final class PredicatedDroppingIterable<A> implements Iterable<A> {
 
     @Override
     public Iterator<A> iterator() {
-        Fn1<? super A, ? extends Boolean> metaPredicate = a -> any(p -> p.apply(a), predicates);
-        return new PredicatedDroppingIterator<>(metaPredicate, as.iterator());
+        return new PredicatedDroppingIterator<>(predicates, as.iterator());
     }
 }

--- a/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterable.java
+++ b/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterable.java
@@ -7,7 +7,7 @@ import java.util.Iterator;
 
 public final class PredicatedDroppingIterable<A> implements Iterable<A> {
     private final ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates;
-    private final Iterable<A> as;
+    private final Iterable<A>                                       as;
 
     public PredicatedDroppingIterable(Fn1<? super A, ? extends Boolean> predicate, Iterable<A> as) {
         ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates = ImmutableQueue.singleton(predicate);

--- a/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterable.java
+++ b/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterable.java
@@ -2,6 +2,7 @@ package com.jnape.palatable.lambda.internal.iteration;
 
 import com.jnape.palatable.lambda.functions.Fn1;
 import com.jnape.palatable.lambda.functions.builtin.fn2.DropWhile;
+import com.jnape.palatable.lambda.internal.ImmutableQueue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -16,15 +17,15 @@ import static com.jnape.palatable.lambda.functions.builtin.fn3.Times.times;
 import static java.util.Collections.singletonList;
 
 public final class PredicatedDroppingIterable<A> implements Iterable<A> {
-    private final List<Fn1<? super A, ? extends Boolean>> predicates;
+    private final ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates;
     private final Iterable<A> as;
 
     public PredicatedDroppingIterable(Fn1<? super A, ? extends Boolean> predicate, Iterable<A> as) {
-        List<Fn1<? super A, ? extends Boolean>> predicates = new ArrayList<>(singletonList(predicate));
+        ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates = ImmutableQueue.singleton(predicate);
         while (as instanceof PredicatedDroppingIterable) {
             PredicatedDroppingIterable<A> nested = (PredicatedDroppingIterable<A>) as;
             as = nested.as;
-            predicates.addAll(0, nested.predicates);
+            predicates = nested.predicates.concat(predicates);
         }
         this.predicates = predicates;
         this.as = as;

--- a/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterator.java
+++ b/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterator.java
@@ -8,7 +8,7 @@ import java.util.NoSuchElementException;
 
 public final class PredicatedDroppingIterator<A> extends ImmutableIterator<A> {
     private final Iterator<Fn1<? super A, ? extends Boolean>> predicates;
-    private final RewindableIterator<A> rewindableIterator;
+    private final RewindableIterator<A>                       rewindableIterator;
 
     public PredicatedDroppingIterator(ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates, Iterator<A> asIterator) {
         this.predicates = predicates.iterator();
@@ -30,15 +30,12 @@ public final class PredicatedDroppingIterator<A> extends ImmutableIterator<A> {
     }
 
     private void dropElementsIfNecessary() {
-
         while (predicates.hasNext() && rewindableIterator.hasNext()) {
             Fn1<? super A, ? extends Boolean> predicate = predicates.next();
             boolean predicateDone = false;
 
             while (rewindableIterator.hasNext() && !predicateDone) {
-                A next = rewindableIterator.next();
-                Boolean apply = predicate.apply(next);
-                if (!apply) {
+                if (!predicate.apply(rewindableIterator.next())) {
                     rewindableIterator.rewind();
                     predicateDone = true;
                 }

--- a/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterator.java
+++ b/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterator.java
@@ -1,17 +1,18 @@
 package com.jnape.palatable.lambda.internal.iteration;
 
 import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.internal.ImmutableQueue;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
 public final class PredicatedDroppingIterator<A> extends ImmutableIterator<A> {
-    private final List<Fn1<? super A, ? extends Boolean>> predicates;
+    private final ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates;
     private final RewindableIterator<A> rewindableIterator;
     private boolean finishedDropping;
 
-    public PredicatedDroppingIterator(List<Fn1<? super A, ? extends Boolean>> predicates, Iterator<A> asIterator) {
+    public PredicatedDroppingIterator(ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates, Iterator<A> asIterator) {
         this.predicates = predicates;
         rewindableIterator = new RewindableIterator<>(asIterator);
         finishedDropping = false;

--- a/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterator.java
+++ b/src/main/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIterator.java
@@ -4,18 +4,15 @@ import com.jnape.palatable.lambda.functions.Fn1;
 import com.jnape.palatable.lambda.internal.ImmutableQueue;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 
 public final class PredicatedDroppingIterator<A> extends ImmutableIterator<A> {
-    private final ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates;
+    private final Iterator<Fn1<? super A, ? extends Boolean>> predicates;
     private final RewindableIterator<A> rewindableIterator;
-    private boolean finishedDropping;
 
     public PredicatedDroppingIterator(ImmutableQueue<Fn1<? super A, ? extends Boolean>> predicates, Iterator<A> asIterator) {
-        this.predicates = predicates;
+        this.predicates = predicates.iterator();
         rewindableIterator = new RewindableIterator<>(asIterator);
-        finishedDropping = false;
     }
 
     @Override
@@ -33,11 +30,11 @@ public final class PredicatedDroppingIterator<A> extends ImmutableIterator<A> {
     }
 
     private void dropElementsIfNecessary() {
-        if(finishedDropping)
-            return;
 
-        for (Fn1<? super A, ? extends Boolean> predicate : predicates) {
+        while (predicates.hasNext() && rewindableIterator.hasNext()) {
+            Fn1<? super A, ? extends Boolean> predicate = predicates.next();
             boolean predicateDone = false;
+
             while (rewindableIterator.hasNext() && !predicateDone) {
                 A next = rewindableIterator.next();
                 Boolean apply = predicate.apply(next);
@@ -46,8 +43,7 @@ public final class PredicatedDroppingIterator<A> extends ImmutableIterator<A> {
                     predicateDone = true;
                 }
             }
-        }
 
-        finishedDropping = true;
+        }
     }
 }

--- a/src/main/java/com/jnape/palatable/lambda/internal/iteration/RewindableIterator.java
+++ b/src/main/java/com/jnape/palatable/lambda/internal/iteration/RewindableIterator.java
@@ -54,9 +54,7 @@ public final class RewindableIterator<A> extends ImmutableIterator<A> {
             if (cache == null)
                 throw new NoSuchElementException("Cache is empty.");
 
-            A cache = this.cache;
-            this.cache = null;
-            return cache;
+            return this.cache;
         }
 
         public boolean isEmpty() {

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileTest.java
@@ -63,6 +63,6 @@ public class DropWhileTest {
     @Test
     public void eachLayerIsAppliedOnce() {
         assertThat(dropWhile(i -> i % 2 == 0, dropWhile(i -> i % 2 == 1, asList(1, 2, 3))),
-                iterates(3));
+                   iterates(3));
     }
 }

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn2/DropWhileTest.java
@@ -56,7 +56,13 @@ public class DropWhileTest {
             innerInvocations.add(x);
             return x > 2;
         }, asList(1, 2, 3))).forEach(__ -> {});
-        assertThat(innerInvocations, iterates(1, 2, 3));
-        assertThat(outerInvocations, iterates(1, 2));
+        assertThat(innerInvocations, iterates(1));
+        assertThat(outerInvocations, iterates(1, 2, 3));
+    }
+
+    @Test
+    public void eachLayerIsAppliedOnce() {
+        assertThat(dropWhile(i -> i % 2 == 0, dropWhile(i -> i % 2 == 1, asList(1, 2, 3))),
+                iterates(3));
     }
 }

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIteratorTest.java
@@ -1,6 +1,7 @@
 package com.jnape.palatable.lambda.internal.iteration;
 
 import com.jnape.palatable.lambda.functions.Fn1;
+import com.jnape.palatable.lambda.internal.ImmutableQueue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,7 +28,7 @@ public class PredicatedDroppingIteratorTest {
 
     @Before
     public void setUp() {
-        predicatedDroppingIterator = new PredicatedDroppingIterator<>(singletonList(EVEN), iterator);
+        predicatedDroppingIterator = new PredicatedDroppingIterator<>(ImmutableQueue.singleton(EVEN), iterator);
     }
 
     @Test

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/PredicatedDroppingIteratorTest.java
@@ -7,9 +7,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static testsupport.Mocking.mockIteratorToHaveValues;
@@ -25,7 +27,7 @@ public class PredicatedDroppingIteratorTest {
 
     @Before
     public void setUp() {
-        predicatedDroppingIterator = new PredicatedDroppingIterator<>(EVEN, iterator);
+        predicatedDroppingIterator = new PredicatedDroppingIterator<>(singletonList(EVEN), iterator);
     }
 
     @Test

--- a/src/test/java/com/jnape/palatable/lambda/internal/iteration/RewindableIteratorTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/internal/iteration/RewindableIteratorTest.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static testsupport.Mocking.mockIteratorToHaveValues;
 
@@ -51,13 +52,14 @@ public class RewindableIteratorTest {
         rewindableIterator.rewind();
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void cannotRewindTheSameElementTwice() {
+    @Test
+    public void canRewindTheSameElementTwice() {
         mockIteratorToHaveValues(iterator, 1, 2, 3);
         rewindableIterator.next();
         rewindableIterator.rewind();
         rewindableIterator.next();
         rewindableIterator.rewind();
+        assertEquals(1, rewindableIterator.next());
     }
 
     @Test


### PR DESCRIPTION
- DropWhile was dropping as long as either predicate held as opposed to doing them in order
- RewindableIterator now supports rewinding the same element multiple times