### PR TITLE
Lambda Hacknight Changes

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/functions/specialized/SemigroupFactory.java
+++ b/src/main/java/com/jnape/palatable/lambda/functions/specialized/SemigroupFactory.java
@@ -1,6 +1,7 @@
 package com.jnape.palatable.lambda.functions.specialized;
 
 import com.jnape.palatable.lambda.functions.Fn3;
+import com.jnape.palatable.lambda.internal.Runtime;
 import com.jnape.palatable.lambda.semigroup.Semigroup;
 
 @FunctionalInterface
@@ -11,7 +12,11 @@ public interface SemigroupFactory<A, B> extends Fn3<A, B, B, B> {
 
     @Override
     default Semigroup<B> apply(A a) {
-        return Fn3.super.apply(a)::apply;
+        try {
+            return checkedApply(a);
+        } catch (Throwable t) {
+            throw Runtime.throwChecked(t);
+        }
     }
 
     @Override

--- a/src/main/java/com/jnape/palatable/lambda/semigroup/ShortCircuitingSemigroup.java
+++ b/src/main/java/com/jnape/palatable/lambda/semigroup/ShortCircuitingSemigroup.java
@@ -1,0 +1,35 @@
+package com.jnape.palatable.lambda.semigroup;
+
+import com.jnape.palatable.lambda.functions.recursion.RecursiveResult;
+import com.jnape.palatable.lambda.functor.builtin.Lazy;
+
+import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Id.id;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Into.into;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.terminate;
+import static com.jnape.palatable.lambda.functions.recursion.Trampoline.trampoline;
+
+public interface ShortCircuitingSemigroup<A> extends Semigroup<A> {
+    RecursiveResult<A, A> shortCircuitApply(A a1, A a2);
+
+    @Override
+    default A checkedApply(A a, A a2) throws Throwable {
+        return shortCircuitApply(a, a2).match(id(), id());
+    }
+
+    @Override
+    default A foldLeft(A a, Iterable<A> as) {
+        return trampoline(
+                into((acc, it) -> !it.hasNext() ? terminate(acc) : shortCircuitApply(acc, it.next())
+                        .<RecursiveResult<A, A>>match(RecursiveResult::recurse,
+                                                      RecursiveResult::terminate)
+                        .biMapL(a3 -> tuple(a3, it))),
+                tuple(a, as.iterator()));
+    }
+
+    @Override
+    default Lazy<A> foldRight(A a, Iterable<A> as) {
+        return Semigroup.super.foldRight(a, as);
+    }
+
+}

--- a/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/Intersection.java
+++ b/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/Intersection.java
@@ -2,13 +2,18 @@ package com.jnape.palatable.lambda.semigroup.builtin;
 
 import com.jnape.palatable.lambda.functions.Fn1;
 import com.jnape.palatable.lambda.functions.builtin.fn1.Distinct;
-import com.jnape.palatable.lambda.semigroup.Semigroup;
+import com.jnape.palatable.lambda.functions.recursion.RecursiveResult;
+import com.jnape.palatable.lambda.semigroup.ShortCircuitingSemigroup;
 
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Constantly.constantly;
 import static com.jnape.palatable.lambda.functions.builtin.fn1.Distinct.distinct;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Empty.empty;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Eq.eq;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Filter.filter;
 import static com.jnape.palatable.lambda.functions.builtin.fn2.Find.find;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.recurse;
+import static com.jnape.palatable.lambda.functions.recursion.RecursiveResult.terminate;
+import static java.util.Collections.emptyList;
 
 /**
  * Given two {@link Iterable Iterables} <code>xs</code> and <code>ys</code>, return the {@link Distinct distinct}
@@ -16,16 +21,11 @@ import static com.jnape.palatable.lambda.functions.builtin.fn2.Find.find;
  *
  * @param <A> the {@link Iterable} element type
  */
-public final class Intersection<A> implements Semigroup<Iterable<A>> {
+public final class Intersection<A> implements ShortCircuitingSemigroup<Iterable<A>> {
 
     private static final Intersection<?> INSTANCE = new Intersection<>();
 
     private Intersection() {
-    }
-
-    @Override
-    public Iterable<A> checkedApply(Iterable<A> xs, Iterable<A> ys) {
-        return filter(x -> find(eq(x), ys).fmap(constantly(true)).orElse(false), distinct(xs));
     }
 
     @SuppressWarnings("unchecked")
@@ -39,5 +39,12 @@ public final class Intersection<A> implements Semigroup<Iterable<A>> {
 
     public static <A> Iterable<A> intersection(Iterable<A> xs, Iterable<A> ys) {
         return intersection(xs).apply(ys);
+    }
+
+    @Override
+    public RecursiveResult<Iterable<A>, Iterable<A>> shortCircuitApply(Iterable<A> a1, Iterable<A> a2) {
+        if (empty(a1) || empty(a2))
+            return terminate(emptyList());
+        return recurse(filter(x -> find(eq(x), a1).fmap(constantly(true)).orElse(false), distinct(a2)));
     }
 }

--- a/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/Intersection.java
+++ b/src/main/java/com/jnape/palatable/lambda/semigroup/builtin/Intersection.java
@@ -47,4 +47,9 @@ public final class Intersection<A> implements ShortCircuitingSemigroup<Iterable<
             return terminate(emptyList());
         return recurse(filter(x -> find(eq(x), a1).fmap(constantly(true)).orElse(false), distinct(a2)));
     }
+
+    @Override
+    public Iterable<A> checkedApply(Iterable<A> xs, Iterable<A> ys) {
+        return filter(x -> find(eq(x), ys).fmap(constantly(true)).orElse(false), distinct(xs));
+    }
 }

--- a/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/AbsentTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/AbsentTest.java
@@ -69,6 +69,12 @@ public class AbsentTest {
         result = Absent.<Unit>absent(Constantly::constantly)
                 .foldLeft(nothing(), repeat(just(UNIT)));
         assertEquals(nothing(), result);
+
+        result = Absent.<Unit>absent()
+                .apply(Constantly::constantly)
+                .foldLeft(nothing(), repeat(just(UNIT)));
+
+        assertEquals(nothing(), result);
     }
 
     @Test(timeout = 200)

--- a/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/CollapseTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/CollapseTest.java
@@ -1,10 +1,24 @@
 package com.jnape.palatable.lambda.semigroup.builtin;
 
+import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.adt.Unit;
+import com.jnape.palatable.lambda.adt.hlist.Tuple2;
+import com.jnape.palatable.lambda.functions.builtin.fn1.Constantly;
+import com.jnape.palatable.lambda.functor.builtin.Lazy;
 import com.jnape.palatable.lambda.semigroup.Semigroup;
 import org.junit.Test;
 
+import static com.jnape.palatable.lambda.adt.Maybe.just;
+import static com.jnape.palatable.lambda.adt.Maybe.nothing;
+import static com.jnape.palatable.lambda.adt.Unit.UNIT;
 import static com.jnape.palatable.lambda.adt.hlist.HList.tuple;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Cons.cons;
+import static com.jnape.palatable.lambda.functions.builtin.fn2.Zip.zip;
+import static com.jnape.palatable.lambda.monoid.builtin.And.and;
 import static com.jnape.palatable.lambda.monoid.builtin.Join.join;
+import static com.jnape.palatable.lambda.monoid.builtin.Or.or;
+import static com.jnape.palatable.lambda.semigroup.builtin.Absent.absent;
 import static com.jnape.palatable.lambda.semigroup.builtin.Collapse.collapse;
 import static org.junit.Assert.assertEquals;
 
@@ -12,10 +26,38 @@ public class CollapseTest {
 
     @Test
     public void semigroup() {
-        Semigroup<String>  join = join();
-        Semigroup<Integer> add  = Integer::sum;
+        Semigroup<String> join = join();
+        Semigroup<Integer> add = Integer::sum;
 
         Collapse<String, Integer> collapse = collapse();
         assertEquals(tuple("foobar", 3), collapse.apply(join, add, tuple("foo", 1), tuple("bar", 2)));
+    }
+
+    @Test(timeout = 200)
+    public void foldLeftShortCircuits() {
+        Semigroup<Tuple2<Boolean, Boolean>> collapse = collapse(and(), or());
+        Iterable<Tuple2<Boolean, Boolean>> tuples = zip(cons(false, repeat(true)),
+                                                        cons(true, repeat(false)));
+        Tuple2<Boolean, Boolean> booleanBooleanTuple2 = collapse.foldLeft(tuple(true, false),
+                                                                          tuples);
+        assertEquals(tuple(false, true),
+                     booleanBooleanTuple2);
+    }
+
+    @Test(timeout = 200)
+    public void foldRightShortCircuits() {
+        Semigroup<Maybe<Unit>> absent = absent(Constantly::constantly);
+        Semigroup<Tuple2<Maybe<Unit>, Maybe<Unit>>> collapse = collapse(absent, absent);
+
+        Lazy<Tuple2<Maybe<Unit>, Maybe<Unit>>> maybeLazy = collapse
+                .foldRight(tuple(just(UNIT), just(UNIT)),
+                           repeat(tuple(nothing(), nothing())));
+        Tuple2<Maybe<Unit>, Maybe<Unit>> result = maybeLazy.value();
+        assertEquals(tuple(nothing(), nothing()), result);
+
+        result = collapse
+                .foldRight(tuple(nothing(), nothing()),
+                           repeat(tuple(just(UNIT), just(UNIT)))).value();
+        assertEquals(tuple(nothing(), nothing()), result);
     }
 }

--- a/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/IntersectionTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/builtin/IntersectionTest.java
@@ -1,5 +1,6 @@
 package com.jnape.palatable.lambda.semigroup.builtin;
 
+import com.jnape.palatable.lambda.adt.Unit;
 import com.jnape.palatable.lambda.functions.Fn1;
 import com.jnape.palatable.traitor.annotations.TestTraits;
 import com.jnape.palatable.traitor.runners.Traits;
@@ -10,6 +11,8 @@ import testsupport.traits.FiniteIteration;
 import testsupport.traits.InfiniteIterableSupport;
 import testsupport.traits.Laziness;
 
+import static com.jnape.palatable.lambda.adt.Unit.UNIT;
+import static com.jnape.palatable.lambda.functions.builtin.fn1.Repeat.repeat;
 import static com.jnape.palatable.lambda.semigroup.builtin.Intersection.intersection;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -39,5 +42,11 @@ public class IntersectionTest {
         assertThat(intersection(asList(1, 2, 3), asList(2, 3, 4)), iterates(2, 3));
         assertThat(intersection(singletonList(1), singletonList(2)), isEmpty());
         assertThat(intersection(asList(1, 2, 3, 3), singletonList(3)), iterates(3));
+    }
+
+    @Test(timeout = 200)
+    public void foldLeftShortCircuits() {
+        assertThat(Intersection.<Unit>intersection().foldLeft(emptyList(), repeat(singletonList(UNIT))), isEmpty());
+        assertThat(Intersection.<Unit>intersection().foldLeft(singletonList(UNIT), repeat(emptyList())), isEmpty());
     }
 }


### PR DESCRIPTION
I'll split this up into multiple PRs. Mostly creating this draft as a springboard for discussion.

Topics addressed:

- Override `checkedApply` on SemigroupFactory to help resolve checkedApply/apply incoherence
- Introduced a `ShortCircuitingSemigroup` with the hope of making short circuiting an easier pattern to add to semigroups/monoids in the future.
    - Does not address foldRight.
    - I'm not sure this is a good idea or if there's a better way to incorporate laziness
- Make collapse short circuit if it's underlying semigroups do 