### PR TITLE
add automatic module name to jar manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.jnape.palatable.lambda</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This allows downstream projects using lambda to publish their own jars as modules without switching lambda itself to a jigsaw module.

Otherwise projects get an error as described in https://stackoverflow.com/questions/46501047/what-does-required-filename-based-automodules-detected-warning-mean