### PR TITLE
FoldRight fixes for Monoid/Semigroup

### DIFF
--- a/src/main/java/com/jnape/palatable/lambda/monoid/Monoid.java
+++ b/src/main/java/com/jnape/palatable/lambda/monoid/Monoid.java
@@ -82,7 +82,7 @@ public interface Monoid<A> extends Semigroup<A> {
      */
     @Override
     default Lazy<A> foldRight(A a, Iterable<A> as) {
-        return lazy(() -> flip().foldMap(id(), reverse(cons(a, as))));
+        return lazy(() -> flip().foldMap(id(), cons(a, reverse(as))));
     }
 
     /**

--- a/src/main/java/com/jnape/palatable/lambda/semigroup/Semigroup.java
+++ b/src/main/java/com/jnape/palatable/lambda/semigroup/Semigroup.java
@@ -39,7 +39,7 @@ public interface Semigroup<A> extends Fn2<A, A, A> {
      * @see FoldRight
      */
     default Lazy<A> foldRight(A a, Iterable<A> as) {
-        return FoldRight.foldRight((y, lazyX) -> lazyX.fmap(x -> apply(x, y)), lazy(a), as);
+        return FoldRight.foldRight((y, lazyX) -> lazyX.fmap(x -> apply(y, x)), lazy(a), as);
     }
 
     /**

--- a/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/FoldRightTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/functions/builtin/fn3/FoldRightTest.java
@@ -29,7 +29,7 @@ public class FoldRightTest {
 
     @Test
     public void foldRightAccumulatesRightToLeft() {
-        assertThat(foldRight((a, lazyB) -> lazyB.fmap(b -> explainFold().apply(a, b)),
+        assertThat(foldRight((a, lazyAcc) -> lazyAcc.fmap(acc -> explainFold().apply(a, acc)),
                              lazy("5"),
                              asList("1", "2", "3", "4"))
                            .value(),

--- a/src/test/java/com/jnape/palatable/lambda/monoid/MonoidTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/monoid/MonoidTest.java
@@ -1,6 +1,7 @@
 package com.jnape.palatable.lambda.monoid;
 
 import com.jnape.palatable.lambda.adt.Maybe;
+import com.jnape.palatable.lambda.functor.builtin.Lazy;
 import org.junit.Test;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import static com.jnape.palatable.lambda.adt.Maybe.nothing;
 import static com.jnape.palatable.lambda.monoid.Monoid.monoid;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static testsupport.functions.ExplainFold.explainFold;
 
 public class MonoidTest {
 
@@ -23,6 +25,13 @@ public class MonoidTest {
     public void reduceRight() {
         Monoid<Integer> sum = monoid(Integer::sum, 0);
         assertEquals((Integer) 6, sum.reduceRight(asList(1, 2, 3)));
+    }
+
+    @Test
+    public void foldRight() {
+        Lazy<String> lazyString = monoid(explainFold()::apply, "0")
+                .foldRight("4", asList("1", "2", "3"));
+        assertEquals("(1 + (2 + (3 + (4 + 0))))", lazyString.value());
     }
 
     @Test

--- a/src/test/java/com/jnape/palatable/lambda/semigroup/SemigroupTest.java
+++ b/src/test/java/com/jnape/palatable/lambda/semigroup/SemigroupTest.java
@@ -4,18 +4,19 @@ import org.junit.Test;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static testsupport.functions.ExplainFold.explainFold;
 
 public class SemigroupTest {
 
     @Test
     public void foldLeft() {
-        Semigroup<Integer> sum = (x, y) -> x + y;
-        assertEquals((Integer) 6, sum.foldLeft(0, asList(1, 2, 3)));
+        Semigroup<String> foldFn = explainFold()::apply;
+        assertEquals("(((0 + 1) + 2) + 3)", foldFn.foldLeft("0", asList("1", "2", "3")));
     }
 
     @Test
     public void foldRight() {
-        Semigroup<Integer> sum = (x, y) -> x + y;
-        assertEquals((Integer) 6, sum.foldRight(0, asList(1, 2, 3)).value());
+        Semigroup<String> foldFn = explainFold()::apply;
+        assertEquals("(1 + (2 + (3 + 0)))", foldFn.foldRight("0", asList("1", "2", "3")).value());
     }
 }

--- a/src/test/java/testsupport/functions/ExplainFold.java
+++ b/src/test/java/testsupport/functions/ExplainFold.java
@@ -7,6 +7,6 @@ import static java.lang.String.format;
 public class ExplainFold {
 
     public static Fn2<String, String, String> explainFold() {
-        return (acc, x) -> format("(%s + %s)", acc, x);
+        return (x, y) -> format("(%s + %s)", x, y);
     }
 }


### PR DESCRIPTION
Addressing https://github.com/palatable/lambda/issues/127

- Semigroup::foldRight had parameters flipped
- Monoid::foldRight was accumulating the accumulator from the left. This has been fixed but the identity is now used as a starting accumulator. Otherwise, the evaluation order is unchanged.
- Changed ExplainFold parameter name since the accumulator can be in either position

_Sidenote_
`Monoid::foldMap` seems to be where short-circuiting is currently implemented. Something that was going to be addressed in the incomplete https://github.com/palatable/lambda/pull/122/files. For obvious reasons, it doesn't seem to address semigroups that should short-circuit. In addition, it has some odd behavior for `Monoid::foldRight`. For example the function application will now match `Semigroup::foldRight`, but `and().foldRight(true, repeat(false)).value()` does not short circuit with the current implementation of `Monoid::foldRight`. I'm tempted to remove `foldLeft`/`foldRight` from `Monoid` and add a `lazilyApply` to `Semigroup` that would allow for users to override for short-circuiting behavior.